### PR TITLE
Extend WikiPathways linkset to mouse and rat

### DIFF
--- a/.github/workflows/create-linkset-wikipathways.yml
+++ b/.github/workflows/create-linkset-wikipathways.yml
@@ -22,19 +22,26 @@ jobs:
           wget -O linkset-creator-v2.0.jar \
             https://github.com/CyTargetLinker/linksetCreator/releases/download/v2.0/linkset-creator-v2.0.jar
 
-      - name: Restore BridgeDb file from cache
-        uses: actions/cache@v4
-        id: cache-bridgedb
-        with:
-          path: ${{ github.workspace }}/bridgedb/Hs_Derby_Ensembl_111.bridge
-          key: ${{ runner.os }}-Hs_Derby_Ensembl_111
-
-      - name: Download BridgeDb file if cache missed
-        if: steps.cache-bridgedb.outputs.cache-hit != 'true'
+      - name: Download BridgeDb files (latest figshare URLs from bridgedb/data)
         run: |
-          mkdir -p "${{ github.workspace }}/bridgedb"
-          wget -O "${{ github.workspace }}/bridgedb/Hs_Derby_Ensembl_111.bridge" \
-            "https://zenodo.org/record/14779056/files/Hs_Derby_Ensembl_111.bridge?download=1"
+          mkdir -p bridgedb
+          # gene.json in github.com/bridgedb/data holds the latest per-species .bridge URLs.
+          curl -sL "https://raw.githubusercontent.com/bridgedb/data/main/gene.json" -o gene.json
+          ua="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+          for entry in \
+            "Homo sapiens|hsa" \
+            "Mus musculus|mmu" \
+            "Rattus norvegicus|rno"; do
+            org="${entry%|*}"; code="${entry#*|}"
+            url=$(jq -r --arg o "$org" '.mappingFiles[] | select(.species==$o) | .downloadURL' gene.json)
+            # figshare needs the ndownloader host + a browser UA/Referer
+            norm="${url/https:\/\/figshare.com\/ndownloader/https:\/\/ndownloader.figshare.com}"
+            echo "Downloading $code bridge ($org) from $norm"
+            wget --quiet --user-agent="$ua" --header="Referer: https://figshare.com/" \
+              -O "bridgedb/${code}.bridge" "$norm"
+            unzip -t "bridgedb/${code}.bridge" >/dev/null 2>&1 || { echo "BAD ZIP: ${code}.bridge"; exit 1; }
+          done
+          ls -la bridgedb/
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -48,24 +55,28 @@ jobs:
       - name: Check ls
         run: ls -la
 
-      - name: Create Linkset XGMML file
+      - name: Create Linkset XGMML files
         run: |
-          java -jar -Dfile.encoding="UTF-8" linkset-creator-v2.0.jar \
-            -c wikipathways/wp.config \
-            -i input.txt \
-            -o wikipathways.xgmml
+          for code in hsa mmu rno; do
+            echo "=== $code ==="
+            java -jar -Dfile.encoding="UTF-8" linkset-creator-v2.0.jar \
+              -c "wikipathways/wp_${code}.config" \
+              -i "input_${code}.txt" \
+              -o "wikipathways_${code}.xgmml"
+          done
+          ls -la wikipathways_*.xgmml
 
-      - name: QC validate linkset
-        run: python3 scripts/qc_xgmml.py --min-nodes 1 --min-edges 1 wikipathways.xgmml
+      - name: QC validate linksets
+        run: python3 scripts/qc_xgmml.py --min-nodes 1 --min-edges 1 wikipathways_hsa.xgmml wikipathways_mmu.xgmml wikipathways_rno.xgmml
 
       - name: Check ls
         run: ls -la
 
-      - name: Upload linkset artifact
+      - name: Upload linkset artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: wikipathways-linkset
-          path: wikipathways.xgmml
+          name: wikipathways-linksets
+          path: wikipathways_*.xgmml
 
       - name: Install curl and jq
         run: sudo apt-get install -y curl jq
@@ -129,24 +140,26 @@ jobs:
               "https://zenodo.org/api/deposit/depositions/${{ env.new_deposition_id }}/files/$file_id"
           done
 
-      - name: Upload linkset to Zenodo
+      - name: Upload linksets to Zenodo
         run: |
-          echo "Uploading wikipathways.xgmml..."
-          curl --progress-bar \
-            -H "Authorization: Bearer ${{ secrets.ZENODO_ACCESS_TOKEN }}" \
-            --upload-file wikipathways.xgmml \
-            "${{ env.new_bucket_url }}/wikipathways.xgmml"
+          for f in wikipathways_hsa.xgmml wikipathways_mmu.xgmml wikipathways_rno.xgmml; do
+            echo "Uploading $f..."
+            curl --progress-bar \
+              -H "Authorization: Bearer ${{ secrets.ZENODO_ACCESS_TOKEN }}" \
+              --upload-file "$f" \
+              "${{ env.new_bucket_url }}/$f"
+          done
 
       - name: Update Metadata for New Version
         run: |
           version=20260510
           current_date=$(date +%Y-%m-%d)
           metadata=$(jq -n \
-            --arg title "WikiPathways Linksets Homo Sapiens" \
+            --arg title "WikiPathways Linksets" \
             --arg version "$version" \
             --arg date "$current_date" \
             --argjson communities '[{"identifier": "cytargetlinker"}]' \
-            --arg description "<p>This dataset is a linkset network containing pathway-gene interactions for all human WikiPathways pathways in XGMML format.</p>" \
+            --arg description "<p>This dataset contains linkset networks of pathway-gene interactions for all human, mouse, and rat WikiPathways pathways in XGMML format.</p>" \
             --argjson creators '[
               {"name": "Kutmon, Martina", "affiliation": "Maastricht University", "orcid": "0000-0002-7699-8191"},
               {"name": "Martens, Marvin", "affiliation": "Maastricht University", "orcid": "0000-0003-2230-0840"},

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Python
+__pycache__/
+*.pyc
+
+# Downloaded source data
+*.gmt
+*.gz
+
+# BridgeDb identifier-mapping files
+*.bridge
+bridgedb/
+gene.json
+
+# linkset-creator jar (downloaded in CI)
+linkset-creator-*.jar
+
+# Generated pipeline outputs
+input_*.txt
+*.xgmml
+*.log

--- a/wikipathways/wp.py
+++ b/wikipathways/wp.py
@@ -3,46 +3,63 @@ import csv
 import gseapy as gp
 import requests
 
-# gmt version
-version = "20260510"
-gmt = "wikipathways-" + version + "-gmt-Homo_sapiens.gmt"
+# WikiPathways GMT release
+VERSION = "20260510"
+BASE_URL = "https://data.wikipathways.org"
 
-# Download from URL
-url = "https://data.wikipathways.org/" + version + "/gmt/" + gmt
-response = requests.get(url)
+# (WikiPathways species token in the GMT filename, CyTargetLinker short code)
+SPECIES = [
+    ("Homo_sapiens", "hsa"),
+    ("Mus_musculus", "mmu"),
+    ("Rattus_norvegicus", "rno"),
+]
 
-# Save and read
-with open(gmt, "w") as f:
-    f.write(response.text)
 
-# Read GMT file
-gene_sets = gp.read_gmt(gmt)
+def process(species_token, code):
+    gmt = f"wikipathways-{VERSION}-gmt-{species_token}.gmt"
+    url = f"{BASE_URL}/{VERSION}/gmt/{gmt}"
+    print(f"{species_token} ({code}): downloading {url}")
+    response = requests.get(url)
+    response.raise_for_status()
+    with open(gmt, "w") as f:
+        f.write(response.text)
 
-with open("input.txt", "w", newline="", encoding="utf-8") as f:
-    writer = csv.writer(f, delimiter="\t")  # Tab-separated
+    gene_sets = gp.read_gmt(gmt)
 
-    # Write header
-    writer.writerow(
-        [
-            "pathway_name",
-            "pathway_id",
-            "gene_count",
-            "gene_id",
-            "gene_symbol",
-            "version",
-            "species",
-        ]
-    )
+    out = f"input_{code}.txt"
+    rows = 0
+    with open(out, "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f, delimiter="\t")  # Tab-separated
+        writer.writerow(
+            [
+                "pathway_name",
+                "pathway_id",
+                "gene_count",
+                "gene_id",
+                "gene_symbol",
+                "version",
+                "species",
+            ]
+        )
+        # GMT set name: "Pathway name%WikiPathways_<date>%WP####%Species"
+        for pathway_name, genes in gene_sets.items():
+            parts = pathway_name.split("%")
+            p_name = parts[0]
+            gmt_version = parts[1]
+            pathway_id = parts[2]
+            species = parts[3]
+            for gene in genes:
+                writer.writerow(
+                    [p_name, pathway_id, len(genes), gene, gene, gmt_version, species]
+                )
+                rows += 1
+    print(f"  wrote {out} ({rows} interactions)")
 
-    # Access data
-    for pathway_name, genes in gene_sets.items():
-        parts = pathway_name.split("%")
-        p_name = parts[0]  # "Clock controlled autophagy in bone metabolism"
-        version = parts[1]  # "WikiPathways_20251110"
-        pathway_id = parts[2]  # "WP5205"
-        species = parts[3]  # "Homo sapiens"
-        
-        for gene in genes:
-            writer.writerow(
-                [p_name, pathway_id, len(genes), gene, gene, version, species]
-            )
+
+def main():
+    for species_token, code in SPECIES:
+        process(species_token, code)
+
+
+if __name__ == "__main__":
+    main()

--- a/wikipathways/wp_hsa.config
+++ b/wikipathways/wp_hsa.config
@@ -1,0 +1,16 @@
+name=WikiPathways pathway-gene network
+organism=Homo sapiens
+version=WikiPathways_20260510
+source_columns=0,1,2
+target_columns=3,4
+edge_columns=5,6
+interaction_type=Pathway-gene
+source_id_column=1
+source_type=pathway
+source_label_column=0
+target_id_column=3
+target_type=gene
+target_bridgedb=bridgedb/hsa.bridge
+target_syscode_in=L
+target_syscodes_out=En,H,L,S
+target_label_column=4

--- a/wikipathways/wp_mmu.config
+++ b/wikipathways/wp_mmu.config
@@ -1,0 +1,16 @@
+name=WikiPathways pathway-gene network
+organism=Mus musculus
+version=WikiPathways_20260510
+source_columns=0,1,2
+target_columns=3,4
+edge_columns=5,6
+interaction_type=Pathway-gene
+source_id_column=1
+source_type=pathway
+source_label_column=0
+target_id_column=3
+target_type=gene
+target_bridgedb=bridgedb/mmu.bridge
+target_syscode_in=L
+target_syscodes_out=En,L,S
+target_label_column=4

--- a/wikipathways/wp_rno.config
+++ b/wikipathways/wp_rno.config
@@ -1,5 +1,5 @@
 name=WikiPathways pathway-gene network
-organism=Homo sapiens
+organism=Rattus norvegicus
 version=WikiPathways_20260510
 source_columns=0,1,2
 target_columns=3,4
@@ -10,7 +10,7 @@ source_type=pathway
 source_label_column=0
 target_id_column=3
 target_type=gene
-target_bridgedb=bridgedb/Hs_Derby_Ensembl_111.bridge
+target_bridgedb=bridgedb/rno.bridge
 target_syscode_in=L
-target_syscodes_out=En,H,L,S
+target_syscodes_out=En,L,S
 target_label_column=4


### PR DESCRIPTION
Builds WikiPathways pathway-gene linksets for **mouse** and **rat** alongside human, into one combined Zenodo record.

- `wp.py` loops human/mouse/rat GMTs (release 20260510), writing `input_<code>.txt` per species.
- `wp.config` split into per-species `wp_hsa/mmu/rno.config` (organism + BridgeDb file).
- Workflow fetches the three BridgeDb files from github.com/bridgedb/data, builds + QCs a linkset per species, uploads all three, and publishes to the combined Zenodo record 4500958 (retitled "WikiPathways Linksets").
- Adds a `.gitignore` for generated artifacts.

Verified locally: mouse (11,178 edges) and rat (4,686 edges) linksets build and pass QC, with Ensembl cross-refs mapped.

Note: stacks on #8 (clear inherited Zenodo files) — its commit is included here; merge #8 first or merge this to supersede it.