### PR TITLE
Add GO-gene linkset (human), split by aspect with true-path propagation

### DIFF
--- a/.github/workflows/create-linkset-go.yml
+++ b/.github/workflows/create-linkset-go.yml
@@ -1,0 +1,71 @@
+name: Create GO linkset
+
+on:
+  workflow_dispatch:
+
+jobs:
+  create-linkset:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+
+      - name: Restore linkset-creator jar from cache
+        uses: actions/cache@v4
+        id: cache-jar
+        with:
+          path: ./linkset-creator-v2.0.jar
+          key: cached-linkset-creator-v2.0-jar
+
+      - name: Download linkset-creator jar if cache missed
+        if: steps.cache-jar.outputs.cache-hit != 'true'
+        run: |
+          wget -O linkset-creator-v2.0.jar \
+            https://github.com/CyTargetLinker/linksetCreator/releases/download/v2.0/linkset-creator-v2.0.jar
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+
+      - name: Install dependencies with pip
+        run: pip3 install requests
+
+      - name: Run preprocessing (downloads gene2go, writes input_hsa.txt)
+        run: python3 go/go.py
+
+      - name: Install jq
+        run: sudo apt-get install -y jq
+
+      - name: Download human BridgeDb file (latest figshare URL from bridgedb/data)
+        run: |
+          mkdir -p bridgedb
+          # gene.json in github.com/bridgedb/data holds the latest per-species .bridge URLs.
+          curl -sL "https://raw.githubusercontent.com/bridgedb/data/main/gene.json" -o gene.json
+          ua="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+          url=$(jq -r '.mappingFiles[] | select(.species=="Homo sapiens") | .downloadURL' gene.json)
+          # figshare needs the ndownloader host + a browser UA/Referer
+          norm="${url/https:\/\/figshare.com\/ndownloader/https:\/\/ndownloader.figshare.com}"
+          echo "Downloading human bridge from $norm"
+          wget --quiet --user-agent="$ua" --header="Referer: https://figshare.com/" \
+            -O bridgedb/hsa.bridge "$norm"
+          unzip -t bridgedb/hsa.bridge >/dev/null 2>&1 || { echo "BAD ZIP: hsa.bridge"; exit 1; }
+
+      - name: Create Linkset XGMML file
+        run: |
+          java -jar -Dfile.encoding="UTF-8" linkset-creator-v2.0.jar \
+            -c go/go_hsa.config \
+            -i input_hsa.txt \
+            -o go_hsa.xgmml
+          ls -la go_hsa.xgmml
+
+      - name: Upload linkset artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: go-linkset
+          path: go_hsa.xgmml

--- a/.github/workflows/create-linkset-go.yml
+++ b/.github/workflows/create-linkset-go.yml
@@ -56,16 +56,20 @@ jobs:
             -O bridgedb/hsa.bridge "$norm"
           unzip -t bridgedb/hsa.bridge >/dev/null 2>&1 || { echo "BAD ZIP: hsa.bridge"; exit 1; }
 
-      - name: Create Linkset XGMML file
+      - name: Create & QC one linkset per GO aspect (BP / MF / CC)
         run: |
-          java -jar -Dfile.encoding="UTF-8" linkset-creator-v2.0.jar \
-            -c go/go_hsa.config \
-            -i input_hsa.txt \
-            -o go_hsa.xgmml
-          ls -la go_hsa.xgmml
+          for a in bp mf cc; do
+            java -jar -Dfile.encoding="UTF-8" linkset-creator-v2.0.jar \
+              -c go/go_hsa_${a}.config \
+              -i input_hsa_${a}.txt \
+              -o go_hsa_${a}.xgmml
+            python3 scripts/qc_xgmml.py --min-nodes 1 --min-edges 1 \
+              --mapped-type gene --min-mapped-frac 0.9 go_hsa_${a}.xgmml
+          done
+          ls -la go_hsa_*.xgmml
 
-      - name: Upload linkset artifact
+      - name: Upload linkset artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: go-linkset
-          path: go_hsa.xgmml
+          name: go-linksets
+          path: go_hsa_*.xgmml

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 # Downloaded source data
 *.gz
 gene2go*
+*.obo
 
 # BridgeDb identifier-mapping files
 *.bridge

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Python
+__pycache__/
+*.pyc
+
+# Downloaded source data
+*.gz
+gene2go*
+
+# BridgeDb identifier-mapping files
+*.bridge
+bridgedb/
+
+# linkset-creator jar (downloaded in CI)
+linkset-creator-*.jar
+
+# Generated pipeline outputs
+input_*.txt
+*.xgmml
+*.log

--- a/go/go.py
+++ b/go/go.py
@@ -1,0 +1,99 @@
+"""GO -> gene preprocessing for CyTargetLinker linksets.
+
+Downloads NCBI gene2go and writes one tab-delimited input_<code>.txt per species
+in the column order expected by go_<code>.config:
+
+    go_id  go_term  gene_id  gene_id(label)  evidence  aspect  qualifier  pubmed
+
+Only experimental evidence codes are kept (curated experimental annotations);
+negated (NOT-qualified) annotations are dropped. gene2go carries Entrez Gene IDs
+(BridgeDb syscode L), so the linkset matches the WikiPathways gene identifiers.
+
+gene2go has no release version, so VERSION is just a date stamp for the linkset
+name. To add species, append (tax_id, code) tuples to SPECIES and add a config.
+"""
+
+import csv
+import gzip
+import os
+
+import requests
+
+VERSION = "20260601"
+GENE2GO_URL = "https://ftp.ncbi.nlm.nih.gov/gene/DATA/gene2go.gz"
+LOCAL = "gene2go.gz"
+
+# (NCBI tax_id, CyTargetLinker short code) — human only for now
+SPECIES = [
+    ("9606", "hsa"),
+]
+
+# GO experimental evidence codes (core experimental + high-throughput experimental).
+# See http://geneontology.org/docs/guide-go-evidence-codes/
+EXPERIMENTAL = {
+    "EXP", "IDA", "IPI", "IMP", "IGI", "IEP",   # core experimental
+    "HTP", "HDA", "HMP", "HGI", "HEP",          # high-throughput experimental
+}
+
+# gene2go columns (tab-separated; header line starts with '#')
+# 0 tax_id  1 GeneID  2 GO_ID  3 Evidence  4 Qualifier  5 GO_term  6 PubMed  7 Category
+
+
+def download():
+    """Download gene2go.gz, reusing an existing local copy if present."""
+    if os.path.exists(LOCAL) and os.path.getsize(LOCAL) > 0:
+        print(f"using existing {LOCAL}")
+        return LOCAL
+    print(f"downloading {GENE2GO_URL}")
+    with requests.get(GENE2GO_URL, stream=True, timeout=600) as resp:
+        resp.raise_for_status()
+        with open(LOCAL, "wb") as f:
+            for chunk in resp.iter_content(chunk_size=1 << 20):
+                f.write(chunk)
+    print(f"  saved {LOCAL}")
+    return LOCAL
+
+
+def main():
+    local = download()
+    writers = {}
+    files = {}
+    counts = {code: 0 for _, code in SPECIES}
+    taxmap = {tax: code for tax, code in SPECIES}
+
+    for code in taxmap.values():
+        f = open(f"input_{code}.txt", "w", newline="", encoding="utf-8")
+        files[code] = f
+        w = csv.writer(f, delimiter="\t")
+        w.writerow(
+            ["go_id", "go_term", "gene_id", "gene_label",
+             "evidence", "aspect", "qualifier", "pubmed"]
+        )
+        writers[code] = w
+
+    # Stream the gzip line-by-line; the full file is ~10 GB uncompressed.
+    with gzip.open(local, "rt", encoding="utf-8") as fh:
+        reader = csv.reader(fh, delimiter="\t")
+        for row in reader:
+            if not row or row[0].startswith("#") or len(row) < 8:
+                continue
+            tax, gene_id, go_id, evidence, qualifier, go_term, pubmed, category = row[:8]
+            code = taxmap.get(tax)
+            if code is None:
+                continue
+            if evidence not in EXPERIMENTAL:
+                continue
+            if "NOT" in qualifier:  # drop negated annotations
+                continue
+            writers[code].writerow(
+                [go_id, go_term, gene_id, gene_id, evidence, category, qualifier, pubmed]
+            )
+            counts[code] += 1
+
+    for code, f in files.items():
+        f.close()
+        print(f"{code}: wrote input_{code}.txt ({counts[code]} interactions)")
+
+
+if __name__ == "__main__":
+    main()

--- a/go/go.py
+++ b/go/go.py
@@ -3,14 +3,37 @@
 Downloads NCBI gene2go and writes one tab-delimited input_<code>.txt per species
 in the column order expected by go_<code>.config:
 
-    go_id  go_term  gene_id  gene_id(label)  evidence  aspect  qualifier  pubmed
+    go_id  go_term  gene_id  gene_label  evidence  aspect  qualifier  pubmed
 
 Only experimental evidence codes are kept (curated experimental annotations);
 negated (NOT-qualified) annotations are dropped. gene2go carries Entrez Gene IDs
 (BridgeDb syscode L), so the linkset matches the WikiPathways gene identifiers.
 
+GO-hierarchy propagation (true-path rule)
+-----------------------------------------
+gene2go records only the most specific (direct) annotation for each gene. By the
+GO true-path rule a gene annotated to a term is implicitly annotated to all of
+that term's ancestors, so a direct-only linkset leaves high-level terms looking
+almost empty (e.g. "response to decreased oxygen levels" had 1 direct human
+gene but ~hundreds with descendants). We therefore download go-basic.obo and, for
+every direct annotation, also emit an edge from the gene to each ancestor term
+reachable via is_a / part_of. (regulates is intentionally excluded: a regulator
+of process X is not a participant in X, so propagating gene annotations across it
+would be biologically wrong.) Ancestor term names come from the ontology.
+
+Each GO-term -> gene pair is written exactly once. A pair can be reached from
+several direct annotations (directly and via different descendants), so the
+evidence codes, qualifiers and PubMed IDs of every contributing annotation are
+merged ('|'-joined) into one edge. (linksetCreator does not de-duplicate edges
+itself because GO IDs and Entrez IDs never collide.)
+
+gene2go has no gene symbol, so the readable label comes from NCBI gene_info
+(GeneID -> Symbol). Without it the genes would appear in Cytoscape as bare
+Entrez numbers. If a symbol is missing the Entrez ID is used as the label.
+
 gene2go has no release version, so VERSION is just a date stamp for the linkset
-name. To add species, append (tax_id, code) tuples to SPECIES and add a config.
+name. To add species, append an entry to SPECIES (tax_id, code, gene_info_url)
+and add a matching go_<code>.config.
 """
 
 import csv
@@ -23,9 +46,28 @@ VERSION = "20260601"
 GENE2GO_URL = "https://ftp.ncbi.nlm.nih.gov/gene/DATA/gene2go.gz"
 LOCAL = "gene2go.gz"
 
-# (NCBI tax_id, CyTargetLinker short code) — human only for now
+# go-basic is the filtered, cycle-free ontology meant for annotation propagation.
+GO_OBO_URL = "https://current.geneontology.org/ontology/go-basic.obo"
+GO_OBO_LOCAL = "go-basic.obo"
+
+# Relationship types over which a gene annotation propagates to ancestor terms.
+PROPAGATE_RELATIONS = {"is_a", "part_of"}
+
+# Drop terms annotated to more than this many genes. After true-path propagation
+# the ontology roots and other near-root terms link to most of the genome
+# (e.g. "molecular_function" -> ~16k genes), which is biologically uninformative
+# and bloats the linkset. This is the standard "too generic" cutoff used in GO
+# enrichment. Set to None to keep every term.
+MAX_GENES = 500
+
+# (NCBI tax_id, CyTargetLinker short code, per-species gene_info.gz URL) — human only for now.
+# gene_info supplies the readable gene Symbol used as the node label.
 SPECIES = [
-    ("9606", "hsa"),
+    (
+        "9606",
+        "hsa",
+        "https://ftp.ncbi.nlm.nih.gov/gene/DATA/GENE_INFO/Mammalia/Homo_sapiens.gene_info.gz",
+    ),
 ]
 
 # GO experimental evidence codes (core experimental + high-throughput experimental).
@@ -38,41 +80,155 @@ EXPERIMENTAL = {
 # gene2go columns (tab-separated; header line starts with '#')
 # 0 tax_id  1 GeneID  2 GO_ID  3 Evidence  4 Qualifier  5 GO_term  6 PubMed  7 Category
 
+# The three GO aspects (gene2go "Category") are written as separate linksets:
+# propagation never crosses namespaces, so each is self-contained. Maps the
+# gene2go category to the output file suffix and a matching go_<code>_<suffix>.config.
+ASPECTS = {
+    "Process": "bp",     # Biological Process
+    "Function": "mf",    # Molecular Function
+    "Component": "cc",   # Cellular Component
+}
 
-def download():
-    """Download gene2go.gz, reusing an existing local copy if present."""
-    if os.path.exists(LOCAL) and os.path.getsize(LOCAL) > 0:
-        print(f"using existing {LOCAL}")
-        return LOCAL
-    print(f"downloading {GENE2GO_URL}")
-    with requests.get(GENE2GO_URL, stream=True, timeout=600) as resp:
+
+def download(url, local):
+    """Download url to local, reusing an existing non-empty local copy."""
+    if os.path.exists(local) and os.path.getsize(local) > 0:
+        print(f"using existing {local}")
+        return local
+    print(f"downloading {url}")
+    with requests.get(url, stream=True, timeout=600) as resp:
         resp.raise_for_status()
-        with open(LOCAL, "wb") as f:
+        with open(local, "wb") as f:
             for chunk in resp.iter_content(chunk_size=1 << 20):
                 f.write(chunk)
-    print(f"  saved {LOCAL}")
-    return LOCAL
+    print(f"  saved {local}")
+    return local
+
+
+def load_symbols(url, tax):
+    """Return {GeneID: Symbol} for one species from an NCBI gene_info.gz file.
+
+    gene_info columns: 0 tax_id  1 GeneID  2 Symbol  ... A '-' symbol means none.
+    """
+    local = f"gene_info_{tax}.gz"
+    download(url, local)
+    symbols = {}
+    with gzip.open(local, "rt", encoding="utf-8") as fh:
+        reader = csv.reader(fh, delimiter="\t")
+        for row in reader:
+            if not row or row[0].startswith("#") or len(row) < 3:
+                continue
+            if row[0] != tax:
+                continue
+            gene_id, symbol = row[1], row[2]
+            if symbol and symbol != "-":
+                symbols[gene_id] = symbol
+    print(f"  loaded {len(symbols)} symbols for tax {tax}")
+    return symbols
+
+
+def parse_obo(path):
+    """Parse go-basic.obo into (parents, names, alt_ids).
+
+    parents : {GO_id -> set(direct parent GO_ids)} over PROPAGATE_RELATIONS
+    names   : {GO_id -> term name}
+    alt_ids : {secondary GO_id -> primary GO_id}
+    Obsolete terms are skipped.
+    """
+    parents, names, alt_ids = {}, {}, {}
+    cur, par, alts, name, obsolete = None, set(), [], None, False
+
+    def flush():
+        if cur and not obsolete:
+            names[cur] = name or cur
+            parents[cur] = par
+            for a in alts:
+                alt_ids[a] = cur
+
+    with open(path, encoding="utf-8") as fh:
+        for line in fh:
+            line = line.rstrip("\n")
+            if line == "[Term]":
+                flush()
+                cur, par, alts, name, obsolete = None, set(), [], None, False
+            elif line.startswith("[") and line.endswith("]"):
+                # a non-Term stanza (e.g. [Typedef]) ends term parsing
+                flush()
+                cur, par, alts, name, obsolete = None, set(), [], None, True
+            elif line.startswith("id: GO:"):
+                cur = line[4:].strip()
+            elif line.startswith("name: "):
+                name = line[6:].strip()
+            elif line.startswith("alt_id: GO:"):
+                alts.append(line[8:].strip())
+            elif line.startswith("is_a: GO:") and "is_a" in PROPAGATE_RELATIONS:
+                par.add(line[6:].split("!", 1)[0].strip())
+            elif line.startswith("relationship: "):
+                rel = line[len("relationship: "):].split("!", 1)[0].split()
+                if len(rel) >= 2 and rel[0] in PROPAGATE_RELATIONS and rel[1].startswith("GO:"):
+                    par.add(rel[1])
+            elif line == "is_obsolete: true":
+                obsolete = True
+    flush()
+    print(f"  parsed {len(names)} GO terms ({len(alt_ids)} alt ids)")
+    return parents, names, alt_ids
+
+
+def build_ancestor_fn(parents):
+    """Return anc(term) -> set of all ancestor terms (memoized, iterative)."""
+    cache = {}
+
+    def anc(term):
+        if term in cache:
+            return cache[term]
+        seen = set()
+        stack = list(parents.get(term, ()))
+        while stack:
+            p = stack.pop()
+            if p in seen:
+                continue
+            seen.add(p)
+            stack.extend(parents.get(p, ()))
+        cache[term] = seen
+        return seen
+
+    return anc
+
+
+def _merge(existing, value):
+    """Append a '|'-delimited token (or tokens) to a set-like ordered list."""
+    for tok in value.split("|"):
+        if tok and tok not in existing:
+            existing.append(tok)
 
 
 def main():
-    local = download()
-    writers = {}
-    files = {}
-    counts = {code: 0 for _, code in SPECIES}
-    taxmap = {tax: code for tax, code in SPECIES}
+    download(GENE2GO_URL, LOCAL)
+    download(GO_OBO_URL, GO_OBO_LOCAL)
+    parents, names, alt_ids = parse_obo(GO_OBO_LOCAL)
+    ancestors = build_ancestor_fn(parents)
 
-    for code in taxmap.values():
-        f = open(f"input_{code}.txt", "w", newline="", encoding="utf-8")
-        files[code] = f
-        w = csv.writer(f, delimiter="\t")
-        w.writerow(
-            ["go_id", "go_term", "gene_id", "gene_label",
-             "evidence", "aspect", "qualifier", "pubmed"]
-        )
-        writers[code] = w
+    taxmap = {tax: code for tax, code, _ in SPECIES}
+    symbol_maps = {code: load_symbols(url, tax) for tax, code, url in SPECIES}
+
+    # Per species: (go_id, gene_id) -> aggregated annotation.
+    pairs = {code: {} for _, code, _ in SPECIES}
+
+    def record(table, go_id, gene_id, term_name, aspect, evidence, qualifier, pubmed):
+        key = (go_id, gene_id)
+        entry = table.get(key)
+        if entry is None:
+            entry = {"go_term": term_name, "aspect": aspect,
+                     "evidence": [], "qualifier": [], "pubmed": []}
+            table[key] = entry
+        _merge(entry["evidence"], evidence)
+        if qualifier:
+            _merge(entry["qualifier"], qualifier)
+        if pubmed and pubmed != "-":
+            _merge(entry["pubmed"], pubmed)
 
     # Stream the gzip line-by-line; the full file is ~10 GB uncompressed.
-    with gzip.open(local, "rt", encoding="utf-8") as fh:
+    with gzip.open(LOCAL, "rt", encoding="utf-8") as fh:
         reader = csv.reader(fh, delimiter="\t")
         for row in reader:
             if not row or row[0].startswith("#") or len(row) < 8:
@@ -85,14 +241,66 @@ def main():
                 continue
             if "NOT" in qualifier:  # drop negated annotations
                 continue
-            writers[code].writerow(
-                [go_id, go_term, gene_id, gene_id, evidence, category, qualifier, pubmed]
-            )
-            counts[code] += 1
 
-    for code, f in files.items():
-        f.close()
-        print(f"{code}: wrote input_{code}.txt ({counts[code]} interactions)")
+            go_id = alt_ids.get(go_id, go_id)  # normalize secondary ids
+            table = pairs[code]
+            # the direct term plus every ancestor (true-path propagation)
+            for term in (go_id, *ancestors(go_id)):
+                record(table, term, gene_id, names.get(term, go_term),
+                       category, evidence, qualifier, pubmed)
+
+    for code, table in pairs.items():
+        symbols = symbol_maps[code]
+
+        # Drop terms that ended up annotated to more than MAX_GENES genes
+        # (ontology roots and other near-root, uninformative terms).
+        dropped_terms = set()
+        if MAX_GENES is not None:
+            gene_count = {}
+            for go_id, _ in table:
+                gene_count[go_id] = gene_count.get(go_id, 0) + 1
+            dropped_terms = {g for g, n in gene_count.items() if n > MAX_GENES}
+            if dropped_terms:
+                dropped_edges = sum(gene_count[g] for g in dropped_terms)
+                print(f"{code}: dropping {len(dropped_terms)} terms with >{MAX_GENES} "
+                      f"genes ({dropped_edges} edges)")
+
+        # One output file per GO aspect (BP / MF / CC).
+        files, writers = {}, {}
+        for suffix in ASPECTS.values():
+            f = open(f"input_{code}_{suffix}.txt", "w", newline="", encoding="utf-8")
+            files[suffix] = f
+            w = csv.writer(f, delimiter="\t")
+            w.writerow(
+                ["go_id", "go_term", "gene_id", "gene_label",
+                 "evidence", "aspect", "qualifier", "pubmed"]
+            )
+            writers[suffix] = w
+
+        written = {s: 0 for s in ASPECTS.values()}
+        genes = {s: set() for s in ASPECTS.values()}
+        for (go_id, gene_id), e in table.items():
+            if go_id in dropped_terms:
+                continue
+            suffix = ASPECTS.get(e["aspect"])
+            if suffix is None:  # unknown category — skip
+                continue
+            label = symbols.get(gene_id, gene_id)
+            # pubmed is the last column: Java's String.split("\t") drops
+            # trailing empty fields, so never leave it empty (use gene2go's
+            # "-" placeholder) or linksetCreator reads a too-short row.
+            writers[suffix].writerow([
+                go_id, e["go_term"], gene_id, label,
+                "|".join(e["evidence"]), e["aspect"],
+                "|".join(e["qualifier"]) or "-", "|".join(e["pubmed"]) or "-",
+            ])
+            written[suffix] += 1
+            genes[suffix].add(gene_id)
+
+        for suffix, f in files.items():
+            f.close()
+            print(f"{code}/{suffix}: wrote input_{code}_{suffix}.txt "
+                  f"({written[suffix]} pairs, {len(genes[suffix])} genes)")
 
 
 if __name__ == "__main__":

--- a/go/go_hsa.config
+++ b/go/go_hsa.config
@@ -1,0 +1,16 @@
+name=GO gene annotations
+organism=Homo sapiens
+version=20260601
+source_columns=0,1
+target_columns=2,3
+edge_columns=4,5,6,7
+interaction_type=GO annotation
+source_id_column=0
+source_type=GO term
+source_label_column=1
+target_id_column=2
+target_type=gene
+target_bridgedb=bridgedb/hsa.bridge
+target_syscode_in=L
+target_syscodes_out=En,H,L,S
+target_label_column=3

--- a/go/go_hsa_bp.config
+++ b/go/go_hsa_bp.config
@@ -1,0 +1,16 @@
+name=GO biological process gene annotations
+organism=Homo sapiens
+version=20260601
+source_columns=0,1
+target_columns=2,3
+edge_columns=4,5,6,7
+interaction_type=GO biological process annotation
+source_id_column=0
+source_type=GO term
+source_label_column=1
+target_id_column=2
+target_type=gene
+target_bridgedb=bridgedb/hsa.bridge
+target_syscode_in=L
+target_syscodes_out=En,H,L,S
+target_label_column=3

--- a/go/go_hsa_cc.config
+++ b/go/go_hsa_cc.config
@@ -1,10 +1,10 @@
-name=GO gene annotations
+name=GO cellular component gene annotations
 organism=Homo sapiens
 version=20260601
 source_columns=0,1
 target_columns=2,3
 edge_columns=4,5,6,7
-interaction_type=GO annotation
+interaction_type=GO cellular component annotation
 source_id_column=0
 source_type=GO term
 source_label_column=1

--- a/go/go_hsa_mf.config
+++ b/go/go_hsa_mf.config
@@ -1,0 +1,16 @@
+name=GO molecular function gene annotations
+organism=Homo sapiens
+version=20260601
+source_columns=0,1
+target_columns=2,3
+edge_columns=4,5,6,7
+interaction_type=GO molecular function annotation
+source_id_column=0
+source_type=GO term
+source_label_column=1
+target_id_column=2
+target_type=gene
+target_bridgedb=bridgedb/hsa.bridge
+target_syscode_in=L
+target_syscodes_out=En,H,L,S
+target_label_column=3

--- a/scripts/qc_xgmml.py
+++ b/scripts/qc_xgmml.py
@@ -13,8 +13,15 @@ produced by the linkset-creator carries:
 By default an empty graph (0 nodes or 0 edges) FAILS; pass --allow-empty to
 permit it. --min-nodes / --min-edges add explicit thresholds.
 
+--mapped-type TYPE together with --min-mapped-frac F guards against a silent
+BridgeDb mapping failure: among nodes whose `type` att equals TYPE, it fails
+unless at least fraction F carry more than one identifier (i.e. got expanded to
+cross-references). A mapper that failed to load leaves every node with only its
+input id, which this catches while a non-empty `identifiers` list alone does not.
+
 Usage:
-    python3 qc_xgmml.py [--allow-empty] [--min-nodes N] [--min-edges N] FILE_OR_GLOB...
+    python3 qc_xgmml.py [--allow-empty] [--min-nodes N] [--min-edges N]
+                        [--mapped-type TYPE --min-mapped-frac F] FILE_OR_GLOB...
 
 Each positional argument is treated as a glob (literal paths work too).
 Exit code is 0 only if every matched file passes; 1 otherwise.
@@ -44,10 +51,13 @@ def _att_index(element):
     return by_name, atts
 
 
-def validate_file(path, allow_empty=False, min_nodes=0, min_edges=0):
+def validate_file(path, allow_empty=False, min_nodes=0, min_edges=0,
+                  mapped_type=None, min_mapped_frac=0.0):
     """Validate one XGMML file. Returns (errors, warnings, n_nodes, n_edges)."""
     errors = []
     warnings = []
+    mapped_total = 0   # nodes whose type == mapped_type
+    mapped_ok = 0      # ...of those, with >1 identifier (got cross-references)
 
     try:
         root = ET.parse(path).getroot()
@@ -81,14 +91,20 @@ def validate_file(path, allow_empty=False, min_nodes=0, min_edges=0):
 
         by_name, _ = _att_index(node)
         ident = by_name.get("identifiers")
+        n_ident = 0
         if ident is None:
             errors.append(f"node '{nid}' has no 'identifiers' attribute")
         else:
             values = [c for c in ident if _local(c.tag) == "att"]
+            n_ident = len(values)
             if not values:
                 errors.append(f"node '{nid}' has an empty 'identifiers' list")
         if "type" not in by_name:
             errors.append(f"node '{nid}' has no 'type' attribute")
+        elif mapped_type is not None and by_name["type"].get("value") == mapped_type:
+            mapped_total += 1
+            if n_ident > 1:
+                mapped_ok += 1
         if "label" not in by_name and node.get("label") is None:
             warnings.append(f"node '{nid}' has no 'label'")
 
@@ -123,6 +139,18 @@ def validate_file(path, allow_empty=False, min_nodes=0, min_edges=0):
     if n_edges < min_edges:
         errors.append(f"only {n_edges} edges (min-edges={min_edges})")
 
+    if mapped_type is not None and min_mapped_frac > 0.0:
+        if mapped_total == 0:
+            errors.append(f"no nodes of type '{mapped_type}' to check mapping coverage")
+        else:
+            frac = mapped_ok / mapped_total
+            if frac < min_mapped_frac:
+                errors.append(
+                    f"only {mapped_ok}/{mapped_total} ({frac:.1%}) '{mapped_type}' nodes "
+                    f"have cross-references (min-mapped-frac={min_mapped_frac:.0%}); "
+                    "BridgeDb mapping may have failed"
+                )
+
     return (errors, warnings, n_nodes, n_edges)
 
 
@@ -132,6 +160,10 @@ def main(argv=None):
     parser.add_argument("--allow-empty", action="store_true", help="treat empty graphs as a warning, not an error")
     parser.add_argument("--min-nodes", type=int, default=0, help="fail if fewer than this many nodes")
     parser.add_argument("--min-edges", type=int, default=0, help="fail if fewer than this many edges")
+    parser.add_argument("--mapped-type", default=None,
+                        help="node 'type' value to check BridgeDb mapping coverage for (e.g. gene)")
+    parser.add_argument("--min-mapped-frac", type=float, default=0.0,
+                        help="fail unless this fraction of --mapped-type nodes have >1 identifier")
     args = parser.parse_args(argv)
 
     files = []
@@ -148,7 +180,8 @@ def main(argv=None):
     failed = 0
     for path in files:
         errors, warnings, n_nodes, n_edges = validate_file(
-            path, allow_empty=args.allow_empty, min_nodes=args.min_nodes, min_edges=args.min_edges
+            path, allow_empty=args.allow_empty, min_nodes=args.min_nodes, min_edges=args.min_edges,
+            mapped_type=args.mapped_type, min_mapped_frac=args.min_mapped_frac
         )
         status = "PASS" if not errors else "FAIL"
         if errors:


### PR DESCRIPTION
Adds a Gene Ontology gene-annotation linkset for human, built from NCBI gene2go and restricted to experimental evidence codes.

Two commits:

1. The initial GO-gene linkset (direct annotations only).
2. Aspect split and ontology propagation:
   - gene2go records only the most specific annotation, so high-level terms looked almost empty. go-basic.obo is now downloaded and each direct annotation also emits an edge to every ancestor reachable via is_a / part_of (the GO true-path rule). regulates is excluded on purpose, since a regulator of process X is not a participant in X.
   - After propagation the near-root terms link to most of the genome, so terms annotated to more than MAX_GENES (500) genes are dropped.
   - The three gene2go categories are written as separate linksets (bp/mf/cc) with one config each; propagation never crosses namespaces, so each is self-contained.
   - Gene labels now come from NCBI gene_info, which gene2go lacks, so genes no longer show in Cytoscape as bare Entrez numbers.
   - The QC validator gains --mapped-type/--min-mapped-frac so a silently failed BridgeDb mapper fails the run instead of shipping a linkset whose nodes carry only their input identifier.

Follow-up, not addressed here: GO is CC BY 4.0 and its citation policy asks for the release date and DOI in the attribution. go.py currently hardcodes VERSION rather than reading data-version from the downloaded go-basic.obo, and the go_hsa_*.config files carry no license= field.