### PR TITLE
Move resource detail into per-subfolder readmes and narrow .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,12 @@ __pycache__/
 *.pyc
 
 # Downloaded source data
+# TFLink is a prefix match, not *.tsv, so that checked-in tables such as
+# wikipathways/species.tsv are not swallowed. The .gz variants of the large
+# TFLink tables are already covered by *.gz.
 *.gmt
 *.gz
-*.tsv
-*.tsv.gz
+TFLink_*.tsv
 gene2go*
 *.obo
 
@@ -19,6 +21,8 @@ gene.json
 linkset-creator-*.jar
 
 # Generated pipeline outputs
+# CHEMBL_MoA.py writes plain input.txt, which input_*.txt does not match.
+input.txt
 input_*.txt
 *.xgmml
 *.log

--- a/README.md
+++ b/README.md
@@ -16,23 +16,22 @@ Under construction: This repo automatically generates CyTargetLinker linksets fr
 covered so far; more are being added as they are automated, and the table is
 updated once a resource is built and deposited.
 
-| Resource | Persistent DOI | License |
-| --- | --- | --- |
-| [WikiPathways](https://www.wikipathways.org) (human, mouse, rat) | [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4500957.svg)](https://doi.org/10.5281/zenodo.4500957) | CC BY 4.0 |
-| [Gene Ontology](https://geneontology.org) (BP / MF / CC, human) | not yet deposited | CC BY 4.0 |
-| [TFLink](https://tflink.net) | not yet deposited | Free for non-commercial use |
-| [ChEMBL](https://www.ebi.ac.uk/chembl/) (mechanism of action) | not yet deposited | CC BY-SA 3.0 |
+| Resource | Details | Persistent DOI | License |
+| --- | --- | --- | --- |
+| [WikiPathways](https://www.wikipathways.org) (human, mouse, rat) | [`wikipathways/`](wikipathways/readme.md) | [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4500957.svg)](https://doi.org/10.5281/zenodo.4500957) | CC BY 4.0 |
+| [Gene Ontology](https://geneontology.org) (BP / MF / CC, human) | [`go/`](go/readme.md) | not yet deposited | CC BY 4.0 |
+| [TFLink](https://tflink.net) | [`tflink/`](tflink/readme.md) | not yet deposited | Free for non-commercial use |
+| [ChEMBL](https://www.ebi.ac.uk/chembl/) (mechanism of action) | [`CHEMBL/`](CHEMBL/readme.md) | not yet deposited | CC BY-SA 3.0 |
 
-Each resource name links to its upstream source. The DOI column holds the
-Zenodo *concept* DOI, which always resolves to the latest published version;
-individual versions have their own DOIs. For resources that are not yet
-deposited the license shown is that of the upstream source data, and the
-license of the eventual deposit still needs to be decided.
+Each resource name links to its upstream source, and the Details column links to
+that resource's own readme — how it is built, how to update it to a new release,
+and what is still outstanding. Resource-specific documentation lives there
+rather than in this file.
 
-## Sources
-- **WikiPathways** (`wikipathways/`) — pathway–gene linkset for human, mouse and rat. See `.github/workflows/create-linkset-wikipathways.yml`.
-- **Gene Ontology** (`go/`) — GO term → gene linkset for human, built from NCBI gene2go with experimental evidence codes only, split into one linkset per aspect (BP / MF / CC) and propagated up the ontology by the true-path rule. See `.github/workflows/create-linkset-go.yml`.
-- **TFLink** (`tflink/`) — transcription factor → target gene linkset built from TFLink's small-scale (high-confidence) `simpleFormat` files, for the 6 species that have such data (human, mouse, rat, fruit fly, *C. elegans*, yeast; zebrafish has no small-scale data). See `.github/workflows/create-linkset-tflink.yml`. Produces the `.xgmml` files as a workflow artifact (no upload step yet). TFLink is frozen at v1.0 (2022); bump `VERSION` in `tflink/tflink.py` when a new release appears. Set `CONFIDENCE = "LS"`/`"All"` to build large-scale variants instead (note: human large-scale is ~6.7M interactions).
+The DOI column holds the Zenodo *concept* DOI, which always resolves to the
+latest published version; individual versions have their own DOIs. For resources
+that are not yet deposited the license shown is that of the upstream source data,
+and the license of the eventual deposit still needs to be decided.
 
 ## (Intended) Workflow
 1. Run the bridgeDb update script to update bridgeDb versions for all config files.

--- a/go/readme.md
+++ b/go/readme.md
@@ -1,0 +1,67 @@
+# Gene Ontology linkset
+
+GO term–gene linkset for human, built from NCBI gene2go and the GO ontology.
+Written as three separate linksets, one per GO aspect.
+
+| | |
+| --- | --- |
+| Source | https://geneontology.org (annotations via NCBI gene2go, ontology via go-basic.obo) |
+| License | CC BY 4.0 — see the [GO citation policy](https://geneontology.org/docs/go-citation-policy/) |
+| DOI | not yet deposited |
+| Workflow | `.github/workflows/create-linkset-go.yml` |
+
+## What is included
+
+Only experimental evidence codes are kept, so these are curated experimental
+annotations rather than the full electronic set. Negated (`NOT`-qualified)
+annotations are dropped. gene2go carries Entrez Gene IDs (BridgeDb syscode `L`),
+which is what makes the GO linkset line up with the WikiPathways one.
+
+## Ontology propagation (the true-path rule)
+
+gene2go records only the most specific annotation for each gene. By the GO
+true-path rule a gene annotated to a term is implicitly annotated to all of that
+term's ancestors, so a direct-only linkset leaves high-level terms looking almost
+empty — "response to decreased oxygen levels" had one direct human gene but
+hundreds once descendants were counted.
+
+`go.py` therefore downloads `go-basic.obo` and, for every direct annotation, also
+emits an edge to each ancestor reachable via `is_a` or `part_of`. **`regulates`
+is excluded on purpose**: a regulator of process X is not a participant in X, so
+propagating across it would be biologically wrong.
+
+Two consequences of propagation:
+
+- After propagation the near-root terms link to most of the genome, so terms with
+  more than `MAX_GENES` (500) genes are dropped as uninformative. Set it to
+  `None` to keep everything.
+- The three aspects are written separately (`bp` / `mf` / `cc`) because
+  propagation never crosses namespaces, so each is self-contained.
+
+Each GO term–gene pair is written once. A pair reachable from several direct
+annotations has the evidence codes, qualifiers and PubMed IDs of every
+contributing annotation merged into one edge, `|`-joined.
+
+## Gene labels
+
+gene2go has no gene symbol, so the readable label comes from NCBI `gene_info`
+(GeneID → Symbol). Without it the genes would appear in Cytoscape as bare Entrez
+numbers. If a symbol is missing, the Entrez ID is used instead.
+
+## Versioning and attribution
+
+GO's citation policy asks redistributed data to state the release it came from.
+`go.py` reads the `data-version` header from `go-basic.obo` and `check_version`
+warns when `VERSION` has drifted from the ontology actually downloaded. The
+configs are static files, so correcting a drift is a manual edit: bump `VERSION`
+in `go.py` and `version=` in all three `go_hsa_*.config` files.
+
+## Not done yet
+
+There is no Zenodo deposit step — the workflow builds and QCs the three
+linksets and uploads them as artifacts, but nothing is archived or gets a DOI.
+
+## Adding a species
+
+Append a `(tax_id, code, gene_info_url)` entry to `SPECIES` in `go.py` and add a
+matching `go_<code>_<aspect>.config` for each of the three aspects.

--- a/tflink/readme.md
+++ b/tflink/readme.md
@@ -1,0 +1,46 @@
+# TFLink linkset
+
+Transcription factor → target gene linkset, built from TFLink's small-scale
+(high-confidence) `simpleFormat` files.
+
+| | |
+| --- | --- |
+| Source | https://tflink.net |
+| License | "TFLink is freely available for non-commercial use" |
+| DOI | not yet deposited |
+| Workflow | `.github/workflows/create-linkset-tflink.yml` |
+
+## Species
+
+Six species have small-scale data and are built: human, mouse, rat, fruit fly,
+*C. elegans* and yeast. Zebrafish is excluded because TFLink has no small-scale
+data for it.
+
+Unlike the other resources, **both ends of an edge are genes** — the TF and its
+target — so both are mapped through BridgeDb.
+
+## Confidence level
+
+`CONFIDENCE = "SS"` (small-scale) is the default and is what the high-confidence
+linkset is built from. Set it to `"LS"` or `"All"` to build large-scale variants
+instead, but note the size: human large-scale is roughly 6.7 million
+interactions.
+
+Most files are served as plain `.tsv`; the large tables (LS/All for human and
+mouse) are gzipped, so `tflink.py` falls back to `.tsv.gz` when the plain file is
+absent.
+
+## Versioning
+
+TFLink is frozen at v1.0 (2022). Bump `VERSION` in `tflink.py` when a new release
+appears, and `version=` in the six `tflink_*.config` files to match.
+
+## Not done yet
+
+There is no Zenodo deposit step — the workflow builds and QCs all six species
+and uploads them as artifacts, but nothing is archived or gets a DOI.
+
+Before anything is deposited, the license needs a decision. "Free for
+non-commercial use" is materially more restrictive than the CC licenses on the
+other resources, and it is not obvious that it is compatible with an open Zenodo
+deposit.

--- a/wikipathways/readme.md
+++ b/wikipathways/readme.md
@@ -1,1 +1,43 @@
-Placeholder for readme details
+# WikiPathways linkset
+
+Pathway–gene linkset for human, mouse and rat, built from the WikiPathways GMT
+release.
+
+| | |
+| --- | --- |
+| Source | https://www.wikipathways.org (GMT files from https://data.wikipathways.org) |
+| License | CC BY 4.0 as deposited; WikiPathways content itself is CC0 1.0 |
+| DOI | [10.5281/zenodo.4500957](https://doi.org/10.5281/zenodo.4500957) (concept DOI, resolves to the latest version) |
+| Workflow | `.github/workflows/create-linkset-wikipathways.yml` |
+
+## How it works
+
+`wp.py` downloads `wikipathways-<VERSION>-gmt-<Species>.gmt` for each species in
+`SPECIES` and writes one `input_<code>.txt` per species. The GMT set name packs
+four fields separated by `%`: `pathway name%WikiPathways_<date>%WP####%species`.
+
+`wp_hsa.config`, `wp_mmu.config` and `wp_rno.config` drive the LinksetCreator.
+Genes enter as Entrez (`target_syscode_in=L`) and are expanded through BridgeDb
+to Ensembl, HGNC, Entrez and UniProt (`target_syscodes_out=En,H,L,S`).
+
+This is the only resource with a full pipeline: build, QC, and deposit to
+Zenodo.
+
+## Updating to a new release
+
+1. Bump `VERSION` in `wp.py`.
+2. Bump `version=` in all three `wp_*.config` files to match.
+3. Bump `version=` in the Zenodo metadata step of the workflow.
+
+## Known limitation: gene labels are Entrez IDs, not symbols
+
+The WikiPathways GMT contains only Entrez Gene IDs — there are no symbols in it.
+`wp.py` therefore writes the same value into both the `gene_id` and
+`gene_symbol` columns, and `target_label_column=4` points at that duplicate, so
+gene nodes are labelled with numbers rather than symbols in Cytoscape.
+
+For contrast, the GO linkset avoids this by joining symbols in from NCBI
+`gene_info`, and an earlier SPARQL-based WikiPathways run produced real symbols
+because the query returned a `GeneName` column. Fixing this needs either a
+symbol lookup after the GMT parse or a return to the SPARQL endpoint for the
+input file.


### PR DESCRIPTION
Resource-specific documentation now lives with the resource rather than in the main README.

wikipathways/, go/ and tflink/ each get a readme covering how the linkset is built, how to update it to a new release, and what is still outstanding. The main README drops its Sources section and keeps only the resource table, which gains a Details column linking to each readme. wikipathways/readme.md was a placeholder and is filled in; CHEMBL/readme.md is left exactly as its author wrote it.

Each readme also records something that was previously undocumented: WikiPathways gene labels are Entrez IDs rather than symbols because the GMT carries no symbols at all; the GO propagation excludes regulates on purpose and drops terms above MAX_GENES; TFLink maps genes on both ends of an edge and needs a license decision before it can be deposited.

On .gitignore: *.tsv was broad enough to swallow checked-in tables such as wikipathways/species.tsv, so it is now the TFLink_*.tsv prefix that actually matches what tflink.py downloads. *.tsv.gz went with it, being already covered by *.gz. Added input.txt, which CHEMBL_MoA.py writes and input_*.txt does not match.

Verified with git check-ignore against real filenames: species.tsv and the readmes are tracked, while the TFLink tables (plain and gzipped), gene2go.gz, gene_info_9606.gz, go-basic.obo, the GMT, input.txt and input_hsa.txt are all still ignored.