### PR TITLE
Trim the WikiPathways readme and species table

### DIFF
--- a/wikipathways/readme.md
+++ b/wikipathways/readme.md
@@ -16,16 +16,10 @@ Zenodo.
 
 ## How it works
 
-`wp.py` resolves the WikiPathways release, downloads one GMT per species, and
-writes `input_<code>.txt` plus a generated `config/wp_<code>.config` for each.
-The GMT set name packs four fields separated by `%`:
-`pathway name%WikiPathways_<date>%WP####%species`.
-
-Genes enter as Entrez (`target_syscode_in=L` — every species' GMT uses Entrez
-ids, including the plants and insects) and are expanded through BridgeDb to
-Ensembl, Entrez and UniProt, plus HGNC for human.
-
-It takes two optional arguments:
+`wp.py` resolves the release, downloads one GMT per species, and writes
+`input_<code>.txt` plus a generated `config/wp_<code>.config` for each. Genes
+enter as Entrez (`target_syscode_in=L` for every species) and BridgeDb expands
+them to Ensembl, Entrez and UniProt, plus HGNC for human.
 
 ```bash
 python3 wikipathways/wp.py                        # all species, newest release
@@ -33,130 +27,70 @@ python3 wikipathways/wp.py --species sce aga      # just these two
 python3 wikipathways/wp.py --version 20260510     # a specific release
 ```
 
-`wp.py` also writes `build/version.txt` and `build/manifest.tsv`. The manifest
-lists the species that were **actually built**, and is what every later workflow
-step iterates — so a species skipped during preprocessing can never leave a
-later step looking for a file that was never produced.
+It also writes `build/manifest.tsv`, listing the species **actually built**.
+The workflow iterates that rather than `species.tsv`, so a skipped species can
+never leave a later step looking for a file that was never produced.
 
 ## Updating to a new release
 
 **Nothing to do.** The release is resolved on every run and flows into the GMT
-URLs, the `version=` line of every generated config, and the Zenodo record
-version.
+URLs, every generated config, and the Zenodo record version.
 
-`data.wikipathways.org` keeps only a **rolling 12-month window** of monthly
-releases, so a hardcoded release would eventually 404. `wp.py` therefore walks
-the **dated release directories** on <https://data.wikipathways.org/>
-(`20260710/`, `20260610/`, …) newest first.
-
-It deliberately does not use `/current/`: that is a moving alias and says
-nothing about whether the release behind it is complete, whereas a dated
-directory holding a GMT for **every `core` species** is positive evidence that
-the release shipped. (The stray `20230810` directory is missing mouse and rat,
-and is correctly rejected on exactly this test.) WikiPathways releases on the
-10th of the month, and a release dated otherwise is flagged in the log.
-
-If the newest directory is incomplete — a release still being published — it is
-skipped with a warning and the previous one used. That is safe because the
-workflow refuses to publish a release older than the one already on Zenodo.
-Three directories are tried before giving up, since more than a couple of
-incomplete releases in a row is a problem to report rather than work around.
-
-Downloads then come from the resolved `/<version>/gmt/` path, so a release
-appearing mid-run cannot produce a linkset assembled from two releases.
+`data.wikipathways.org` keeps only a rolling 12-month window, so a pinned
+release would eventually 404. `wp.py` walks the dated release directories
+newest first and accepts one only once it holds a GMT for every `core` species.
+`/current/` is not used: it is an alias that says nothing about whether the
+release behind it is complete. An incomplete newest release is skipped for the
+previous one, which is safe because publishing refuses to go backwards.
 
 ## Adding or removing a species
 
-Everything is driven by [`species.tsv`](species.tsv) — adding a species is one
-line there, and nothing else changes.
+One line in [`species.tsv`](species.tsv); nothing else changes. The columns are
+documented in its header.
 
-```
-code	wp_token	bridgedb_species	syscodes_out	tier	min_mapped_frac
-hsa	Homo_sapiens	Homo sapiens	En,H,L,S	core	0.90
-```
+Five species are listed but commented `off` — pig, horse, poplar, tomato and
+maize have between one and five pathways each. `wp.py` also skips any `extra`
+species below `MIN_PATHWAYS` (5).
 
-- **`wp_token`** — the species as spelled in the GMT filename.
-- **`bridgedb_species`** — the key in bridgedb/data `gene.json`. Stated
-  explicitly rather than derived from `wp_token`, because the two sources can
-  drift (Ensembl now calls the dog *Canis lupus familiaris*) and because the
-  `.bridge` filenames are not derivable from the species name anyway
-  (*Equus caballus* is `Qc_`, *Populus trichocarpa* is `Pi_`).
-- **`syscodes_out`** — BridgeDb systems to expand gene ids into. `H` (HGNC) is
-  human-only.
-- **`tier`** — `core` means a missing GMT fails the run, `extra` means it is
-  skipped with a warning, `off` means it is not built.
-- **`min_mapped_frac`** — the QC floor for BridgeDb coverage (below).
-
-Five species are listed but commented `off` because WikiPathways has too little
-content for them to be useful linksets — pig, horse, poplar, tomato and maize
-each have between one and five pathways. `wp.py` also skips any `extra` species
-below `MIN_PATHWAYS` (5), so one that shrinks again drops out on its own.
-
-## Configs are generated
+## Generated configs
 
 There are no committed per-species configs. Each `config/wp_<code>.config` is
-generated from [`wp.config.template`](wp.config.template) on every run, and the
-whole `config/` directory is gitignored. This is what removes the need to
-hand-maintain the release version across a dozen files.
-
-The generator asserts that every line of a rendered config is exactly one
-`key=value` pair. LinksetCreator's `ConfigFileReader` splits on the first `=`
-but keeps only lines that split into exactly two parts, silently discarding
-anything else — so a value containing `=` would vanish without an error.
+generated from [`wp.config.template`](wp.config.template) on every run, and
+`config/` is gitignored. Do not hand-edit them.
 
 ## Quality control
 
-Each linkset is validated by `scripts/qc_xgmml.py` before anything is published.
-Beyond the structural checks it verifies **BridgeDb mapping coverage**:
+`scripts/qc_xgmml.py` checks structure and **BridgeDb mapping coverage**:
 `--mapped-type gene --min-mapped-frac` fails a linkset unless that fraction of
-gene nodes gained more than one identifier. A mapper that fails to load leaves
-every node carrying only its input id — structurally valid, but useless for
-matching a user's network.
+gene nodes gained more than one identifier. A mapper that failed to load leaves
+every node carrying only its input id — valid XML, useless for matching.
 
-Measured on release 20260710: 100% for most species, 98.9% cow, 95.9% rat. The
-floors are 0.90 for `core` and 0.80 for `extra`. Arabidopsis and Anopheles reach
-100% despite their Ensembl Plants / Metazoa 56 mapping files, which had been
-expected to map the Entrez-keyed GMTs poorly.
+Coverage on release 20260710 was 100% for most species, 98.9% cow, 95.9% rat.
+Floors are 0.90 (`core`) and 0.80 (`extra`).
 
-**Any QC failure fails the whole run and publishes nothing.** A partial publish
-would mint a permanent DOI on an incomplete record; a failed run just needs
-re-dispatching.
+Any QC failure fails the whole run and publishes nothing, rather than minting a
+permanent DOI on an incomplete record.
 
 ## Publishing
 
-Three gates protect the Zenodo record, all because published versions are
-immutable. The run will not publish if:
-
-1. the concept record already publishes this WikiPathways release — otherwise a
-   quarterly schedule would mint a new DOI whether or not anything changed;
-2. the built release is **older** than the published one, which could otherwise
-   happen after falling back from an incomplete release;
-3. a file present in the last published version is missing from this build, so a
-   transient upstream 404 cannot silently drop a species.
-
-Publishing needs the `ZENODO_ACCESS_TOKEN` secret. The `skip_zenodo` and
-`force_publish` dispatch inputs make the gates testable.
+Zenodo versions are immutable, so the run will not publish if the release is
+already published, if it is *older* than the published one, or if a file from
+the previous version is missing from this build. Needs the
+`ZENODO_ACCESS_TOKEN` secret; `skip_zenodo` and `force_publish` make the gates
+testable.
 
 ## Note on BridgeDb downloads
 
-Use `scripts/fetch-bridge.sh`; do not hand-roll a download. Figshare redirects
-to a presigned S3 URL that expires in ten seconds, and it answers requests
-carrying a full browser user-agent with `HTTP 202 Accepted` and an empty body.
-202 is a success code, so `wget` exits 0 and writes a zero-byte file, and
-`--retry-on-http-error` cannot match a 2xx — which is exactly how the previous
-download failed, looping until it gave up. The script sends no spoofed
-user-agent and accepts a download only on an explicit 200 that also passes a zip
-test.
+Use `scripts/fetch-bridge.sh`. Figshare redirects to a presigned S3 URL that
+expires in ten seconds, and answers browser-like user agents with `HTTP 202
+Accepted` and an empty body. 202 is a success code, so `wget` exits 0 and writes
+a zero-byte file — which is how the previous download failed. The script sends
+no spoofed user-agent and accepts only an explicit 200 that passes a zip test.
 
 ## Known limitation: gene labels are Entrez IDs, not symbols
 
-The WikiPathways GMT contains only Entrez Gene IDs — there are no symbols in it.
-`wp.py` therefore writes the same value into both the `gene_id` and
-`gene_symbol` columns, and `target_label_column=4` points at that duplicate, so
-gene nodes are labelled with numbers rather than symbols in Cytoscape.
-
-For contrast, the GO linkset avoids this by joining symbols in from NCBI
-`gene_info`, and an earlier SPARQL-based WikiPathways run produced real symbols
-because the query returned a `GeneName` column. Fixing this needs either a
-symbol lookup after the GMT parse or a return to the SPARQL endpoint for the
-input file.
+The GMT contains only Entrez Gene IDs, so `wp.py` writes the same value into
+both the `gene_id` and `gene_symbol` columns and gene nodes are labelled with
+numbers in Cytoscape. The GO linkset avoids this by joining symbols in from NCBI
+`gene_info`; fixing it here needs either that or a return to the SPARQL
+endpoint.

--- a/wikipathways/species.tsv
+++ b/wikipathways/species.tsv
@@ -1,26 +1,11 @@
-# The species built by wp.py. This is the only place the species list lives:
-# the per-species .config files, the workflow's build/QC loops and the Zenodo
-# file list are all derived from it (via build/manifest.tsv).
+# The species built by wp.py. This is the only place the species list lives.
 #
-# code             CyTargetLinker short code; names input_<code>.txt,
-#                  wp_<code>.config and wikipathways_<code>.xgmml
-# wp_token         species as spelled in the GMT filename
-#                  (wikipathways-<version>-gmt-<wp_token>.gmt)
-# bridgedb_species species key in bridgedb/data gene.json. Stated explicitly
-#                  rather than derived from wp_token: the two sources can drift
-#                  (Ensembl now calls the dog Canis lupus familiaris) and the
-#                  .bridge filenames are not derivable from the name anyway
-#                  (Equus caballus -> Qc_, Populus trichocarpa -> Pi_).
-# syscodes_out     BridgeDb cross-reference systems to expand gene ids into.
-#                  H (HGNC) is human-only; everything else gets En,L,S.
-# tier             core = a missing GMT fails the whole run.
-#                  extra = a missing or near-empty GMT is skipped with a warning.
-#                  off  = not built.
-# min_mapped_frac  QC floor: fraction of gene nodes that must gain
-#                  cross-references, else the run fails (see scripts/qc_xgmml.py).
-#
-# All GMTs use NCBI Entrez gene ids regardless of species, so target_syscode_in
-# is L for every row and is not a column.
+# code              names input_<code>.txt, config/wp_<code>.config, wikipathways_<code>.xgmml
+# wp_token          species as spelled in the GMT filename
+# bridgedb_species  species key in bridgedb/data gene.json (not derivable from wp_token)
+# syscodes_out      BridgeDb systems to expand gene ids into; H (HGNC) is human-only
+# tier              core = a missing GMT fails the run; extra = skipped; off = not built
+# min_mapped_frac   QC floor for BridgeDb cross-reference coverage
 #
 # code	wp_token	bridgedb_species	syscodes_out	tier	min_mapped_frac
 hsa	Homo_sapiens	Homo sapiens	En,H,L,S	core	0.90
@@ -34,17 +19,11 @@ ptr	Pan_troglodytes	Pan troglodytes	En,L,S	extra	0.80
 cfa	Canis_familiaris	Canis familiaris	En,L,S	extra	0.80
 gga	Gallus_gallus	Gallus gallus	En,L,S	extra	0.80
 dme	Drosophila_melanogaster	Drosophila melanogaster	En,L,S	extra	0.80
-# Arabidopsis and Anopheles have Ensembl Plants / Metazoa 56 BridgeDb files
-# rather than Ensembl 111 like the rest, which was expected to map the
-# Entrez-keyed GMTs poorly. Measured on release 20260710 it does not: both
-# reach 100% cross-reference coverage, so they carry the same floor as the
-# other extra species.
 ath	Arabidopsis_thaliana	Arabidopsis thaliana	En,L,S	extra	0.80
 aga	Anopheles_gambiae	Anopheles gambiae	En,L,S	extra	0.80
 #
-# Available in both WikiPathways and BridgeDb, but not built: too few pathways
-# to be a useful linkset (counts from release 20260710). Re-enable by
-# uncommenting and setting tier to extra once WikiPathways has more content.
+# Too few pathways to be a useful linkset (counts from release 20260710).
+# Uncomment and set tier to extra once WikiPathways has more content.
 # eca	Equus_caballus	Equus caballus	En,L,S	off	0.00	5 pathways
 # pop	Populus_trichocarpa	Populus trichocarpa	En,L,S	off	0.00	5 pathways
 # ssc	Sus_scrofa	Sus scrofa	En,L,S	off	0.00	2 pathways


### PR DESCRIPTION
Follow-up to #20: both files had grown explanatory prose that belongs in the commit history rather than in files people read to get something done.

- `wikipathways/readme.md`: 162 → 96 lines
- `wikipathways/species.tsv`: 52 → 31 lines

Kept the non-obvious facts (why `bridgedb_species` is an explicit column, the Figshare 202 trap, the immutability reasoning behind the publish gates) and dropped the justifications around them. No behaviour change; verified the table still parses to the same 13 species with 6 well-formed fields per row.