### PR TITLE
Take TFLink through to release; hold GO before it

### DIFF
--- a/.github/workflows/create-linkset-tflink.yml
+++ b/.github/workflows/create-linkset-tflink.yml
@@ -2,10 +2,38 @@ name: Create TFLink linksets
 
 on:
   workflow_dispatch:
+    inputs:
+      skip_zenodo:
+        description: "Build and QC only, do not touch Zenodo"
+        type: boolean
+        default: false
+      force_publish:
+        description: "Publish even if Zenodo already has this TFLink version"
+        type: boolean
+        default: false
+
+concurrency:
+  # Never run two of these at once: the job mutates a Zenodo draft, and a
+  # cancelled run would leave one dangling.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  # One-time setup: TFLink has no Zenodo record yet. Create an initial
+  # deposition in the cytargetlinker community, publish it once by hand, then
+  # put its two IDs here. Until then the build and QC steps run normally and
+  # the publish steps are skipped with a notice.
+  ZENODO_DEPOSITION_ID: ""
+  # Concept (all-versions) record, used to read what is currently published.
+  ZENODO_CONCEPT_ID: ""
 
 jobs:
   create-linksets:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     steps:
 
       - name: Checkout repo
@@ -85,3 +113,188 @@ jobs:
         with:
           name: tflink-linksets
           path: tflink_*.xgmml
+
+      - name: Decide whether to publish
+        id: gate
+        run: |
+          set -euo pipefail
+          # TFLink is frozen at v1.0 and the confidence level changes what the
+          # linkset contains, so both belong in the version string.
+          tf_version="$(grep -oP '^VERSION\s*=\s*"\K[^"]+' tflink/tflink.py)"
+          tf_conf="$(grep -oP '^CONFIDENCE\s*=\s*"\K[^"]+' tflink/tflink.py)"
+          version="${tf_version}-${tf_conf}"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Built TFLink $version"
+
+          if [ "${{ inputs.skip_zenodo }}" = "true" ]; then
+            echo "skip_zenodo requested; not publishing"
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ -z "${ZENODO_DEPOSITION_ID}" ] || [ -z "${ZENODO_CONCEPT_ID}" ]; then
+            echo "::warning::TFLink has no Zenodo record yet, so nothing was published."
+            {
+              echo "### TFLink not published"
+              echo
+              echo "\`ZENODO_DEPOSITION_ID\` / \`ZENODO_CONCEPT_ID\` are unset in this workflow."
+              echo "Create the initial deposition once by hand, publish it, then set both IDs."
+              echo "See \`tflink/readme.md\`. The linksets built fine and are attached as artifacts."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          zen=$(curl -sSL --retry 3 "https://zenodo.org/api/records/${ZENODO_CONCEPT_ID}")
+          zen_version=$(echo "$zen" | jq -r '.metadata.version // ""')
+          echo "Zenodo latest: ${zen_version:-<none>}"
+
+          if [ "$zen_version" = "$version" ] && [ "${{ inputs.force_publish }}" != "true" ]; then
+            echo "Zenodo already publishes TFLink $version; nothing new to release."
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Zenodo versions are immutable, so never publish a record that has
+          # lost a species relative to the last one.
+          missing=$(comm -23 \
+            <(echo "$zen" | jq -r '.files[].key' | sort) \
+            <(ls -1 tflink_*.xgmml | sort) || true)
+          if [ -n "$missing" ]; then
+            echo "ERROR: these previously published files are absent from this build:"
+            echo "$missing"
+            echo "Refusing to publish a shrinking record. Re-run with force_publish if intended."
+            exit 1
+          fi
+
+          echo "publish=true" >> "$GITHUB_OUTPUT"
+
+      - name: Discard current Zenodo draft
+        if: steps.gate.outputs.publish == 'true'
+        run: |
+          discard_response=$(curl -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.ZENODO_ACCESS_TOKEN }}" \
+            "https://zenodo.org/api/deposit/depositions/${ZENODO_DEPOSITION_ID}/actions/discard")
+          echo "Discard Response: $discard_response"
+          # Non-fatal: no existing draft is fine, so we do not exit on failure here
+
+      - name: Create a new version of the deposition
+        id: new_version
+        if: steps.gate.outputs.publish == 'true'
+        run: |
+          response=$(curl -s -X POST \
+            -H "Authorization: Bearer ${{ secrets.ZENODO_ACCESS_TOKEN }}" \
+            "https://zenodo.org/api/deposit/depositions/${ZENODO_DEPOSITION_ID}/actions/newversion")
+
+          new_draft_url=$(echo "$response" | jq -r '.links.latest_draft')
+          if [[ "$new_draft_url" == "null" || -z "$new_draft_url" ]]; then
+            echo "Failed to retrieve the latest draft URL. Response was: $response"
+            exit 1
+          fi
+
+          new_draft_response=$(curl -s \
+            -H "Authorization: Bearer ${{ secrets.ZENODO_ACCESS_TOKEN }}" \
+            "$new_draft_url")
+
+          new_deposition_id=$(echo "$new_draft_response" | jq -r '.id')
+          new_bucket_url=$(echo "$new_draft_response" | jq -r '.links.bucket')
+
+          if [[ "$new_deposition_id" == "null" || -z "$new_deposition_id" ]]; then
+            echo "Failed to retrieve the new deposition ID. Response was: $new_draft_response"
+            exit 1
+          fi
+
+          echo "New Deposition ID: $new_deposition_id"
+          echo "new_deposition_id=$new_deposition_id" >> $GITHUB_ENV
+          echo "new_bucket_url=$new_bucket_url" >> $GITHUB_ENV
+
+      - name: Clear inherited files from the new draft
+        if: steps.gate.outputs.publish == 'true'
+        run: |
+          # A new Zenodo version is created as a copy of the previous version,
+          # including its files. Remove those inherited files so this version
+          # contains only the freshly built linksets (not stale older ones).
+          files=$(curl -s \
+            -H "Authorization: Bearer ${{ secrets.ZENODO_ACCESS_TOKEN }}" \
+            "https://zenodo.org/api/deposit/depositions/${{ env.new_deposition_id }}/files")
+          echo "$files" | jq -r '.[].id' | while read -r file_id; do
+            [ -z "$file_id" ] && continue
+            echo "Deleting inherited file $file_id"
+            curl -s -X DELETE \
+              -H "Authorization: Bearer ${{ secrets.ZENODO_ACCESS_TOKEN }}" \
+              "https://zenodo.org/api/deposit/depositions/${{ env.new_deposition_id }}/files/$file_id"
+          done
+
+      - name: Upload linksets to Zenodo
+        if: steps.gate.outputs.publish == 'true'
+        run: |
+          set -euo pipefail
+          for f in tflink_*.xgmml; do
+            echo "Uploading $f..."
+            curl --fail --progress-bar \
+              -H "Authorization: Bearer ${{ secrets.ZENODO_ACCESS_TOKEN }}" \
+              --upload-file "$f" \
+              "${{ env.new_bucket_url }}/$f"
+          done
+
+      - name: Update metadata for the new version
+        if: steps.gate.outputs.publish == 'true'
+        run: |
+          set -euo pipefail
+          version="${{ steps.gate.outputs.version }}"
+          current_date=$(date +%Y-%m-%d)
+          n_species=$(ls -1 tflink_*.xgmml | wc -l)
+          description="<p>This dataset contains linkset networks of transcription factor - target gene interactions from TFLink ${version}, in XGMML format, for ${n_species} species.</p><p>Derived from TFLink (https://tflink.net), which is freely available for non-commercial use. Redistributed under CC BY-NC 4.0 accordingly.</p>"
+
+          metadata=$(jq -n \
+            --arg title "TFLink Linksets" \
+            --arg version "$version" \
+            --arg date "$current_date" \
+            --argjson communities '[{"identifier": "cytargetlinker"}]' \
+            --arg description "$description" \
+            --argjson creators '[
+              {"name": "Kutmon, Martina", "affiliation": "Maastricht University", "orcid": "0000-0002-7699-8191"},
+              {"name": "Martens, Marvin", "affiliation": "Maastricht University", "orcid": "0000-0003-2230-0840"},
+              {"name": "Ehrhart, Friederike", "affiliation": "Maastricht University", "orcid": "0000-0002-7770-620X"}
+            ]' \
+            --argjson related_identifiers '[
+              {"identifier": "10.1093/database/baac083", "relation": "isDerivedFrom", "resource_type": "publication-article", "scheme": "doi"},
+              {"identifier": "10.12688/f1000research.14613.1", "relation": "references", "resource_type": "publication-article", "scheme": "doi"}
+            ]' \
+            '{
+              metadata: {
+                title: $title,
+                version: $version,
+                publication_date: $date,
+                description: $description,
+                access_right: "open",
+                upload_type: "dataset",
+                language: "eng",
+                license: "cc-by-nc-4.0",
+                creators: $creators,
+                related_identifiers: $related_identifiers,
+                references: ["Liska O et al (2022) TFLink. Database, baac083. https://doi.org/10.1093/database/baac083"],
+                communities: $communities
+                }
+            }')
+
+          curl -s \
+            -H "Authorization: Bearer ${{ secrets.ZENODO_ACCESS_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -X PUT \
+            --data "$metadata" \
+            "https://zenodo.org/api/deposit/depositions/${{ env.new_deposition_id }}"
+
+      - name: Publish updated Zenodo record
+        if: steps.gate.outputs.publish == 'true'
+        run: |
+          publish_response=$(curl -s \
+            -H "Authorization: Bearer ${{ secrets.ZENODO_ACCESS_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -X POST \
+            "https://zenodo.org/api/deposit/depositions/${{ env.new_deposition_id }}/actions/publish")
+          if echo "$publish_response" | jq -e '.status == "error"' > /dev/null 2>&1; then
+            echo "Publishing failed! Response: $publish_response"
+            exit 1
+          fi
+          echo "Published successfully. DOI: $(echo "$publish_response" | jq -r '.doi')"

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ updated once a resource is built and deposited.
 | Resource | Details | Persistent DOI | License |
 | --- | --- | --- | --- |
 | [WikiPathways](https://www.wikipathways.org) (13 species) | [`wikipathways/`](wikipathways/readme.md) | [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4500957.svg)](https://doi.org/10.5281/zenodo.4500957) | CC BY 4.0 |
-| [Gene Ontology](https://geneontology.org) (BP / MF / CC, human) | [`go/`](go/readme.md) | not yet deposited | CC BY 4.0 |
-| [TFLink](https://tflink.net) | [`tflink/`](tflink/readme.md) | not yet deposited | Free for non-commercial use |
+| [Gene Ontology](https://geneontology.org) (BP / MF / CC, human) | [`go/`](go/readme.md) | not deposited (paused before release) | CC BY 4.0 |
+| [TFLink](https://tflink.net) | [`tflink/`](tflink/readme.md) | not yet deposited | CC BY-NC 4.0 |
 | [ChEMBL](https://www.ebi.ac.uk/chembl/) (mechanism of action) | [`CHEMBL/`](CHEMBL/readme.md) | not yet deposited | CC BY-SA 3.0 |
 
 Each resource name links to its upstream source, and the Details column links to

--- a/go/readme.md
+++ b/go/readme.md
@@ -56,10 +56,16 @@ warns when `VERSION` has drifted from the ontology actually downloaded. The
 configs are static files, so correcting a drift is a manual edit: bump `VERSION`
 in `go.py` and `version=` in all three `go_hsa_*.config` files.
 
-## Not done yet
+## Scope: everything up to release, deliberately
 
-There is no Zenodo deposit step — the workflow builds and QCs the three
-linksets and uploads them as artifacts, but nothing is archived or gets a DOI.
+This resource is **paused before the release step**. The workflow builds the
+three linksets, QCs them and uploads them as artifacts — and stops there. There
+is no Zenodo deposit, so nothing is archived and there is no DOI.
+
+That is a deliberate choice, not an oversight: the GO linkset is not considered
+ready to publish yet. Do not add a deposit step until that changes. When it
+does, the TFLink workflow has the full build → QC → deposit chain to copy, and
+`tflink/readme.md` describes the one-time Zenodo record setup it needs.
 
 ## Adding a species
 

--- a/tflink/readme.md
+++ b/tflink/readme.md
@@ -6,9 +6,23 @@ Transcription factor → target gene linkset, built from TFLink's small-scale
 | | |
 | --- | --- |
 | Source | https://tflink.net |
-| License | "TFLink is freely available for non-commercial use" |
-| DOI | not yet deposited |
+| License | CC BY-NC 4.0 (non-commercial, attribution required) |
+| DOI | not yet deposited — needs the one-time setup below |
 | Workflow | `.github/workflows/create-linkset-tflink.yml` |
+
+## Licensing
+
+TFLink's FAQ states only that "TFLink is freely available for non-commercial
+use", with no license named on the site or the download page. The TFLink paper
+(Liska *et al.* 2022, [10.1093/database/baac083](https://doi.org/10.1093/database/baac083))
+is published under **CC BY-NC 4.0**, which permits non-commercial re-use,
+distribution and reproduction provided the original work is cited.
+
+The linkset is therefore deposited as **CC BY-NC 4.0** — the most permissive
+license consistent with the source. Note this is more restrictive than the
+CC BY 4.0 used for WikiPathways and GO, and an NC license is not "open" in the
+Open Definition sense. If TFLink's terms ever need to be relied on more firmly
+than a paper's license statement, the FAQ suggests contacting the authors.
 
 ## Species
 
@@ -35,12 +49,31 @@ absent.
 TFLink is frozen at v1.0 (2022). Bump `VERSION` in `tflink.py` when a new release
 appears, and `version=` in the six `tflink_*.config` files to match.
 
-## Not done yet
+## Release
 
-There is no Zenodo deposit step — the workflow builds and QCs all six species
-and uploads them as artifacts, but nothing is archived or gets a DOI.
+The workflow runs the full chain: build → QC → deposit to Zenodo, gated the same
+way as WikiPathways. It will not publish when `skip_zenodo` is set, when Zenodo
+already carries this version (unless `force_publish`), or when the build has
+lost a species relative to what is already published — Zenodo versions are
+immutable, so a shrinking record is refused.
 
-Before anything is deposited, the license needs a decision. "Free for
-non-commercial use" is materially more restrictive than the CC licenses on the
-other resources, and it is not obvious that it is compatible with an open Zenodo
-deposit.
+The deposit version string is `<VERSION>-<CONFIDENCE>`, e.g. `v1.0-SS`, because
+the confidence level changes what the linkset contains.
+
+### One-time setup, still outstanding
+
+TFLink has no Zenodo record yet, so `ZENODO_DEPOSITION_ID` and
+`ZENODO_CONCEPT_ID` are empty in the workflow `env:` block. Until they are set,
+every run builds and QCs normally and then skips the publish steps with a notice
+in the job summary — it does not fail.
+
+To finish it:
+
+1. Create a deposition on Zenodo in the `cytargetlinker` community and publish
+   it once by hand, so a concept DOI exists.
+2. Put the published record's ID in `ZENODO_DEPOSITION_ID` and its concept
+   (all-versions) ID in `ZENODO_CONCEPT_ID`.
+3. Add the concept DOI to the resource table in the top-level `README.md`.
+
+After that the workflow versions the record on its own, exactly as the
+WikiPathways one does.


### PR DESCRIPTION
**TFLink: full pipeline.** The workflow now runs build → QC → deposit to Zenodo, gated the same way as WikiPathways. It refuses to publish when skip_zenodo is set, when Zenodo already carries the version (unless force_publish), or when the build has lost a species relative to what is published — Zenodo versions are immutable, so a shrinking record is refused. The deposit version is `<VERSION>-<CONFIDENCE>` (e.g. `v1.0-SS`), since the confidence level changes what the linkset contains.

**The license question is resolved.** TFLink's FAQ says only "TFLink is freely available for non-commercial use" and names no license anywhere on the site or download page. The TFLink paper (Liska et al. 2022, 10.1093/database/baac083) is published under CC BY-NC 4.0, which permits non-commercial re-use, distribution and reproduction provided the original work is cited. The deposit therefore declares `cc-by-nc-4.0` and cites the paper as `isDerivedFrom`. This is more restrictive than the CC BY 4.0 on WikiPathways and GO, and an NC license is not "open" in the Open Definition sense — worth knowing before it goes into the CyTargetLinker community.

**One manual step remains.** TFLink has no Zenodo record yet, so `ZENODO_DEPOSITION_ID` and `ZENODO_CONCEPT_ID` are empty in the workflow env. Until they are filled, runs build and QC normally and skip the publish steps with a notice in the job summary rather than failing. Creating and first-publishing that record needs the Zenodo token and is a deliberate human action, so it is not automated here; `tflink/readme.md` walks through it.

**GO stays put.** No deposit step, everything up to release only. `go/readme.md` now records that as a deliberate hold rather than an omission, so a later reader does not "fix" it as a gap.

Workflow YAML validated and the version extraction checked against the real `tflink.py` (yields `v1.0-SS`).