### PR TITLE
Fix the species separator in the Zenodo description

### DIFF
--- a/.github/workflows/create-linkset-wikipathways.yml
+++ b/.github/workflows/create-linkset-wikipathways.yml
@@ -290,7 +290,11 @@ jobs:
           version="$(cat build/version.txt)"
           current_date=$(date +%Y-%m-%d)
           n_species=$(( $(wc -l < build/manifest.tsv) - 1 ))
-          species_list=$(tail -n +2 build/manifest.tsv | cut -f3 | paste -sd'; ' -)
+          # awk, not `paste -sd'; '`: paste treats -d as a cyclic LIST of
+          # single-char delimiters, so '; ' alternates ';' and ' ' between
+          # items rather than joining with "; ".
+          species_list=$(tail -n +2 build/manifest.tsv | cut -f3 |
+            awk 'BEGIN{ORS=""} NR>1{print "; "} {print}')
           description="<p>This dataset contains linkset networks of pathway-gene interactions from WikiPathways release ${version}, in XGMML format, for ${n_species} species: ${species_list}.</p>"
 
           metadata=$(jq -n \

--- a/scripts/fetch-bridge.sh
+++ b/scripts/fetch-bridge.sh
@@ -46,7 +46,12 @@ delay=2
 i=1
 while :; do
   echo "fetching $norm -> $target (attempt $i/$attempts)"
+  # --speed-limit/--speed-time abandon a transfer that drops below 10 kB/s for
+  # a minute, so a stalled connection is retried in ~1 minute rather than
+  # sitting until --max-time. The cap is generous because these files reach
+  # ~840 MB and Figshare is sometimes genuinely slow rather than stuck.
   http=$(curl -sS -L --max-time 1800 \
+              --speed-limit 10240 --speed-time 60 \
               --retry 3 --retry-delay 2 --retry-connrefused \
               -o "$tmp" -w '%{http_code}' "$norm") || http="000"
 


### PR DESCRIPTION
Two fixes found by running the real publish (#20 follow-up).

**Species separator.** `paste -sd'; '` does not join with `"; "` — `paste` treats `-d` as a *cyclic list* of single-character delimiters, so it alternated `;` and a space. The published 20260710 record reads:

> Homo sapiens;Mus musculus Rattus norvegicus;Bos taurus Saccharomyces cerevisiae;...

Now joined with awk, producing `Homo sapiens; Mus musculus; Rattus norvegicus; ...`. The already-published record's description needs correcting by hand in the Zenodo UI — metadata is editable on a published version, and re-running would only mint a redundant DOI.

**Download stall detection.** Figshare served that same run at a crawl: Drosophila took 11 minutes for 111 MB and Arabidopsis 18 minutes for 160 MB, turning a 3-minute build into 32. No retries fired, so these were slow rather than stuck — but with only `--max-time 1800`, a genuinely stalled connection would have hung for a full 30 minutes before retrying. `--speed-limit 10240 --speed-time 60` now abandons a transfer that drops below 10 kB/s for a minute.

Verified the corrected description against the real 13-species manifest and re-ran the downloader.