### PR TITLE
Record the published TFLink DOI

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ updated once a resource is built and deposited.
 | Resource | Details | Persistent DOI | License |
 | --- | --- | --- | --- |
 | [WikiPathways](https://www.wikipathways.org) (13 species) | [`wikipathways/`](wikipathways/readme.md) | [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4500957.svg)](https://doi.org/10.5281/zenodo.4500957) | CC BY 4.0 |
-| [TFLink](https://tflink.net) | [`tflink/`](tflink/readme.md) | not yet deposited | CC BY-NC 4.0 |
+| [TFLink](https://tflink.net) (5 species) | [`tflink/`](tflink/readme.md) | [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21804828.svg)](https://doi.org/10.5281/zenodo.21804828) | CC BY-NC 4.0 |
 | [ChEMBL](https://www.ebi.ac.uk/chembl/) (mechanism of action) | [`CHEMBL/`](CHEMBL/readme.md) | not yet deposited | CC BY-SA 3.0 |
 
 Each resource name links to its upstream source, and the Details column links to

--- a/tflink/readme.md
+++ b/tflink/readme.md
@@ -80,23 +80,24 @@ the confidence level changes what the linkset contains.
 
 ### Record
 
-Bootstrapped on 2026-08-05; the IDs are set in the workflow `env:` block.
+Bootstrapped and published 2026-08-05, in the `cytargetlinker` community.
 
 | | |
 | --- | --- |
-| Deposition | `21804829` |
-| Concept (all-versions) | `21804828` |
-| Concept DOI | `10.5281/zenodo.21804828` |
+| Concept DOI | [10.5281/zenodo.21804828](https://doi.org/10.5281/zenodo.21804828) — always the latest version |
+| First version | `10.5281/zenodo.21804829` (`v1.0-SS`) |
+| Deposition ID | `21804829` |
+| Concept ID | `21804828` |
 
-**The first version is still an unpublished draft.** Minting a DOI is
-irreversible, so the initial public record was left for a human to review and
-publish: https://zenodo.org/deposit/21804829
+Both IDs are set in the workflow `env:` block, so later runs version the record
+by themselves, exactly as the WikiPathways one does.
 
-Once it is published, add the concept DOI to the resource table in the
-top-level `README.md`. Every later run then versions the record by itself,
-exactly as the WikiPathways one does.
+The account that owns the record is the one `ZENODO_ACCESS_TOKEN` belongs to —
+the same account that owns the WikiPathways deposit. Drafts are only visible to
+that account, so check https://zenodo.org/me/uploads while logged in as it
+rather than looking for a draft URL.
 
-The `bootstrap_zenodo` input that created it refuses to run now that
+The `bootstrap_zenodo` input that created the record refuses to run now that
 `ZENODO_DEPOSITION_ID` is set, so it cannot mint a second record by accident.
 
 ## BridgeDb downloads


### PR DESCRIPTION
The TFLink linkset is live: concept DOI **10.5281/zenodo.21804828**, first version `v1.0-SS` (10.5281/zenodo.21804829), CC BY-NC 4.0, open access, in the `cytargetlinker` community, with all five linksets attached.

Adds the DOI badge to the resource table and replaces the pending-draft notes in `tflink/readme.md` with the published record details. Both the badge and the DOI were checked and resolve.

Also records where drafts actually live, since this cost some confusion: a Zenodo draft is visible only to the account that owns `ZENODO_ACCESS_TOKEN` (the same account that owns the WikiPathways deposit), reachable via zenodo.org/me/uploads rather than any draft URL.