### PR TITLE
Cite the current CyTargetLinker paper version in Zenodo metadata

### DIFF
--- a/.github/workflows/create-linkset-tflink.yml
+++ b/.github/workflows/create-linkset-tflink.yml
@@ -232,7 +232,7 @@ jobs:
             ]' \
             --argjson related_identifiers '[
               {"identifier": "10.1093/database/baac083", "relation": "isDerivedFrom", "resource_type": "publication-article", "scheme": "doi"},
-              {"identifier": "10.12688/f1000research.14613.1", "relation": "references", "resource_type": "publication-article", "scheme": "doi"}
+              {"identifier": "10.12688/f1000research.14613.2", "relation": "references", "resource_type": "publication-article", "scheme": "doi"}
             ]' \
             '{ metadata: {
                  title: $title, version: $version, publication_date: $date,
@@ -355,7 +355,7 @@ jobs:
             ]' \
             --argjson related_identifiers '[
               {"identifier": "10.1093/database/baac083", "relation": "isDerivedFrom", "resource_type": "publication-article", "scheme": "doi"},
-              {"identifier": "10.12688/f1000research.14613.1", "relation": "references", "resource_type": "publication-article", "scheme": "doi"}
+              {"identifier": "10.12688/f1000research.14613.2", "relation": "references", "resource_type": "publication-article", "scheme": "doi"}
             ]' \
             '{
               metadata: {

--- a/.github/workflows/create-linkset-wikipathways.yml
+++ b/.github/workflows/create-linkset-wikipathways.yml
@@ -310,7 +310,7 @@ jobs:
             ]' \
             --argjson related_identifiers '[
               {"identifier": "10.1093/nar/gkad960", "relation": "references", "resource_type": "publication-article", "scheme": "doi"},
-              {"identifier": "10.12688/f1000research.14613.1", "relation": "references", "resource_type": "publication-article", "scheme": "doi"}
+              {"identifier": "10.12688/f1000research.14613.2", "relation": "references", "resource_type": "publication-article", "scheme": "doi"}
             ]' \
             '{
               metadata: {
@@ -324,7 +324,7 @@ jobs:
                 license: "cc-by-4.0",
                 creators: $creators,
                 related_identifiers: $related_identifiers,
-                references: ["Kutmon et al (2018) https://doi.org/10.12688/f1000research.14613.1"],
+                references: ["Kutmon et al (2019) https://doi.org/10.12688/f1000research.14613.2"],
                 communities: $communities
                 }
             }')


### PR DESCRIPTION
The deposits referenced `10.12688/f1000research.14613.1`, the first version of the CyTargetLinker app update paper. Version 2 is the current one (https://f1000research.com/articles/7-743/v2), so both the WikiPathways and TFLink deposits now cite `10.12688/f1000research.14613.2` — four places in total, covering TFLink's bootstrap and publish paths and WikiPathways' related identifiers and references string.

Verified against Crossref: the v2 DOI resolves to "CyTargetLinker app update: A flexible solution for network extension in Cytoscape", Kutmon, Ehrhart, Willighagen, Evelo, Coort, published 2019-08-13.

That date also fixes a second thing — the WikiPathways `references` string said "Kutmon et al (2018)", which was the v1 year. It now reads 2019 to match the version being cited.

Metadata changes only take effect on the next publish, so both records will pick this up on their next run rather than retroactively.