### PR TITLE
Use fetch-bridge.sh for the Orphanet BridgeDb download

### DIFF
--- a/.github/workflows/Create_OrphanetLinkset.yml
+++ b/.github/workflows/Create_OrphanetLinkset.yml
@@ -92,23 +92,7 @@ jobs:
             exit 1
           fi
 
-          normalized_url="${url/https:\/\/figshare.com\/ndownloader/https:\/\/ndownloader.figshare.com}"
-
-          user_agent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/124.0.0.0 Safari/537.36"
-
-          echo "Downloading Homo sapiens BridgeDb file from $normalized_url"
-
-          wget \
-            --quiet \
-            --user-agent="$user_agent" \
-            --header="Referer: https://figshare.com/" \
-            -O "bridgedb/hsa.bridge" \
-            "$normalized_url"
-
-          unzip -t bridgedb/hsa.bridge >/dev/null 2>&1 || {
-            echo "Invalid BridgeDb file: bridgedb/hsa.bridge"
-            exit 1
-          }
+          scripts/fetch-bridge.sh "$url" "bridgedb/hsa.bridge"
 
           ls -la bridgedb/
 


### PR DESCRIPTION
The Orphanet workflow downloaded the human bridge file with `wget` and a spoofed Chrome user-agent — the pattern `scripts/fetch-bridge.sh` exists to replace, and the same one that was just removed from the TFLink workflow.

Figshare answers `HTTP 202 Accepted` with an empty body when it decides the caller is a browser, and a full Chrome UA reliably triggers it. 202 is a success code, so `wget` exits 0 having written nothing. The inline `unzip -t` check caught that, but only as a failed run.

Worth noting the failure is **intermittent** — the last two Orphanet runs succeeded, which is precisely what makes this worth removing rather than leaving to chance.

`fetch-bridge.sh` accepts only an explicit 200 that also passes a zip test, follows Figshare's ten-second presigned redirect immediately rather than re-requesting it, and retries with backoff. The inline URL normalisation and zip check go with it, since the script does both.

Net −20 lines. Workflow YAML and every `run:` block validated.