### PR TITLE
Set the Orphanet Zenodo IDs from the bootstrap run

### DIFF
--- a/.github/workflows/Create_OrphanetLinkset.yml
+++ b/.github/workflows/Create_OrphanetLinkset.yml
@@ -25,10 +25,9 @@ permissions:
   contents: read
 
 env:
-  # Create and publish the first Orphanet Zenodo deposition manually.
-  # Then add the deposition ID and concept ID here.
-  ZENODO_DEPOSITION_ID: ""
-  ZENODO_CONCEPT_ID: ""
+  ZENODO_DEPOSITION_ID: "21805965"
+  # Concept (all-versions) record, used to read what is currently published.
+  ZENODO_CONCEPT_ID: "21805964"
 
 jobs:
   create-linkset:


### PR DESCRIPTION
Bootstrap created deposition **21805965** (concept **21805964**) and uploaded `Orphanet.xgmml` — 8,868 nodes, 8,503 edges, 98.7% of gene nodes carrying BridgeDb cross-references. Both IDs are now set, so the workflow will version the record from here on instead of skipping the deposit.

**The first version is an unpublished draft** awaiting review at zenodo.org/me/uploads (visible only to the account owning the token).

One thing to look at before publishing: the version string came out as `Orphadata_2026-06-23 07:57:31`. It is read from the `date` attribute of `product6.xml`, which carries a full timestamp, so the Zenodo version field has a space and colons in it. Zenodo accepts that, but it reads oddly next to `v1.0-SS` and `20260510` on the other records, and the publish gate compares this string exactly. Trimming it to the date alone would be a one-line change to the gate step — worth doing before the record is published, since the value is baked into each version.