### PR TITLE
Cache the BridgeDb files as a weekly bundle

### DIFF
--- a/.github/workflows/Chembl_MoA.yml
+++ b/.github/workflows/Chembl_MoA.yml
@@ -80,6 +80,21 @@ jobs:
       - name: Install jq
         run: sudo apt-get install -y jq
 
+      # Restore-only: the weekly update-bridgedb workflow owns this cache. On a
+      # hit fetch-bridge.sh finds the file already present and valid and
+      # returns immediately; on a miss it downloads as usual, so a linkset run
+      # never depends on the weekly job having succeeded.
+      - name: Compute the BridgeDb bundle key
+        id: bridgekey
+        run: echo "key=bridgedb-bundle-$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore the BridgeDb bundle
+        uses: actions/cache/restore@v4
+        with:
+          path: bridgedb
+          key: ${{ steps.bridgekey.outputs.key }}
+          restore-keys: bridgedb-bundle-
+
       - name: Download Homo sapiens BridgeDb file
         run: |
           set -euo pipefail
@@ -104,23 +119,7 @@ jobs:
             exit 1
           fi
 
-          normalized_url="${url/https:\/\/figshare.com\/ndownloader/https:\/\/ndownloader.figshare.com}"
-
-          user_agent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/124.0.0.0 Safari/537.36"
-
-          echo "Downloading Homo sapiens BridgeDb file from $normalized_url"
-
-          wget \
-            --quiet \
-            --user-agent="$user_agent" \
-            --header="Referer: https://figshare.com/" \
-            -O "bridgedb/hsa.bridge" \
-            "$normalized_url"
-
-          unzip -t bridgedb/hsa.bridge >/dev/null 2>&1 || {
-            echo "Invalid BridgeDb file: bridgedb/hsa.bridge"
-            exit 1
-          }
+          scripts/fetch-bridge.sh "$url" "bridgedb/hsa.bridge"
 
           ls -la bridgedb/
 

--- a/.github/workflows/Create_OrphanetLinkset.yml
+++ b/.github/workflows/Create_OrphanetLinkset.yml
@@ -71,6 +71,21 @@ jobs:
       - name: Install jq
         run: sudo apt-get install -y jq
 
+      # Restore-only: the weekly update-bridgedb workflow owns this cache. On a
+      # hit fetch-bridge.sh finds the file already present and valid and
+      # returns immediately; on a miss it downloads as usual, so a linkset run
+      # never depends on the weekly job having succeeded.
+      - name: Compute the BridgeDb bundle key
+        id: bridgekey
+        run: echo "key=bridgedb-bundle-$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore the BridgeDb bundle
+        uses: actions/cache/restore@v4
+        with:
+          path: bridgedb
+          key: ${{ steps.bridgekey.outputs.key }}
+          restore-keys: bridgedb-bundle-
+
       - name: Download Homo sapiens BridgeDb file
         run: |
           set -euo pipefail

--- a/.github/workflows/create-linkset-tflink.yml
+++ b/.github/workflows/create-linkset-tflink.yml
@@ -74,6 +74,21 @@ jobs:
       - name: Install jq
         run: sudo apt-get install -y jq
 
+      # Restore-only: the weekly update-bridgedb workflow owns this cache. On a
+      # hit fetch-bridge.sh finds each file already present and valid and
+      # returns immediately; on a miss it downloads as usual, so a linkset run
+      # never depends on the weekly job having succeeded.
+      - name: Compute the BridgeDb bundle key
+        id: bridgekey
+        run: echo "key=bridgedb-bundle-$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore the BridgeDb bundle
+        uses: actions/cache/restore@v4
+        with:
+          path: bridgedb
+          key: ${{ steps.bridgekey.outputs.key }}
+          restore-keys: bridgedb-bundle-
+
       - name: Build & QC one linkset per species
         run: |
           set -euo pipefail

--- a/.github/workflows/create-linkset-wikipathways.yml
+++ b/.github/workflows/create-linkset-wikipathways.yml
@@ -106,6 +106,21 @@ jobs:
 
       # One species at a time, deleting each .bridge right after use: the full
       # set is a few GB, but peak disk stays at the largest single file.
+      # Restore-only: the weekly update-bridgedb workflow owns this cache. On a
+      # hit fetch-bridge.sh finds each file already present and valid and
+      # returns immediately; on a miss it downloads as usual, so a linkset run
+      # never depends on the weekly job having succeeded.
+      - name: Compute the BridgeDb bundle key
+        id: bridgekey
+        run: echo "key=bridgedb-bundle-$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore the BridgeDb bundle
+        uses: actions/cache/restore@v4
+        with:
+          path: bridgedb
+          key: ${{ steps.bridgekey.outputs.key }}
+          restore-keys: bridgedb-bundle-
+
       - name: Build linksets
         run: |
           set -euo pipefail

--- a/.github/workflows/update-bridgedb.yml
+++ b/.github/workflows/update-bridgedb.yml
@@ -1,58 +1,115 @@
-name: Weekly caching of bridge and linksetcreator
+name: Weekly BridgeDb and linkset-creator cache
+
+# Populates two caches the linkset workflows restore instead of downloading:
+#
+#   - the linkset-creator jar (small, static key)
+#   - a bundle of every BridgeDb .bridge file the repo needs (~3.2 GB)
+#
+# Why cache the bundle: the .bridge files are large (human alone is ~840 MB)
+# and the same ones are pulled by several linkset workflows, so fetching them
+# once and reusing the cache saves both time and load on Figshare. GitHub also
+# evicts caches that go 7 days without being read, so a weekly refresh is what
+# keeps the bundle alive.
+#
+# The bundle key is the ISO week, so a new bundle is built each week and picks
+# up any BridgeDb release from that week. Consumers restore the current week's
+# key and fall back to the most recent bundle via the `bridgedb-bundle-`
+# prefix, so a linkset run never blocks on this job having finished. On a miss
+# they download the species they need themselves, exactly as before.
+#
+# Dispatch this workflow manually to pull a BridgeDb release mid-week.
 
 on:
-  repository_dispatch: 
+  repository_dispatch:
     types: [bridgedb-data-update-event]
   workflow_dispatch:
   schedule:
-  - cron: "0 0 * * 0"
+    - cron: "0 0 * * 0"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: false # to allow multiple runs to queue up rather than clobber
 
+permissions:
+  contents: read
+
 jobs:
   refresh-cache:
     runs-on: ubuntu-latest
+    timeout-minutes: 180
     steps:
-    
-      - name: Checkout wikipathways-database repo
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          ref: main
 
-      - name: Setup Java
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: '11'
-            
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
       - name: Cache linkset-creator jar
-        uses: actions/cache@v5
+        uses: actions/cache@v4
         id: cache-linkset-creator-jar
         with:
           path: ./linkset-creator-v2.0.jar
           key: cached-linkset-creator-v2.0-jar   # static key — version is in the name
-      
+
       - name: Download linkset-creator jar
         if: steps.cache-linkset-creator-jar.outputs.cache-hit != 'true'
         run: |
-          echo "Cache miss — downloading linkset-creator jar"
           wget -O linkset-creator-v2.0.jar \
             https://github.com/CyTargetLinker/linksetCreator/releases/download/v2.0/linkset-creator-v2.0.jar
-      
-      - name: Cache BridgeDb file
-        uses: actions/cache@v5
+
+      - name: Compute the bundle cache key
+        id: key
+        run: echo "key=bridgedb-bundle-$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore or create the BridgeDb bundle
+        uses: actions/cache@v4
         id: cache-bridgedb
         with:
-          path: ${{ github.workspace }}/bridgedb/Hs_Derby_Ensembl_111.bridge
-          key: ${{ runner.os }}-Hs_Derby_Ensembl_111   # static key — no hash needed for versioned file
-      
-      - name: Download BridgeDb file
+          path: bridgedb
+          key: ${{ steps.key.outputs.key }}
+
+      - name: Install jq
+        if: steps.cache-bridgedb.outputs.cache-hit != 'true'
+        run: sudo apt-get install -y jq
+
+      - name: Download every BridgeDb file the repo needs
         if: steps.cache-bridgedb.outputs.cache-hit != 'true'
         run: |
-          echo "Cache miss — downloading BridgeDb bridge file"
-          mkdir -p "${{ github.workspace }}/bridgedb"
-          wget -O "${{ github.workspace }}/bridgedb/Hs_Derby_Ensembl_111.bridge" \
-            "https://figshare.com/ndownloader/files/64796817"
+          set -euo pipefail
+          mkdir -p bridgedb
+          curl -sSL --retry 5 --retry-delay 5 \
+            "https://raw.githubusercontent.com/bridgedb/data/main/gene.json" -o gene.json
+
+          # wikipathways/species.tsv is the repo's species list and is a
+          # superset of what the other linksets use, so caching its species
+          # covers TFLink, Orphanet and ChEMBL too.
+          #
+          # Columns here are code / wp_token / bridgedb_species / syscodes_out /
+          # tier / min_mapped_frac. Note this is NOT the layout of
+          # build/manifest.tsv, which the linkset workflows iterate over and
+          # which carries an extra `organism` column before bridgedb_species.
+          while IFS=$'\t' read -r code wp_token bridgedb_species syscodes tier frac rest; do
+            case "$code" in ''|'#'*) continue ;; esac
+            echo "::group::$code ($bridgedb_species)"
+            url=$(jq -r --arg o "$bridgedb_species" \
+                  '.mappingFiles[] | select(.species==$o) | .downloadURL' gene.json)
+            if [ -z "$url" ] || [ "$url" = "null" ]; then
+              echo "ERROR: no BridgeDb mapping file for '$bridgedb_species' in gene.json"
+              exit 1
+            fi
+            scripts/fetch-bridge.sh "$url" "bridgedb/${code}.bridge"
+            echo "::endgroup::"
+          done < wikipathways/species.tsv
+
+          echo "Bundle contents:"
+          du -sh bridgedb
+          ls -la bridgedb/
+
+      - name: Summary
+        run: |
+          {
+            echo "### BridgeDb bundle"
+            echo
+            echo "Key: \`${{ steps.key.outputs.key }}\`"
+            echo "Cache hit: \`${{ steps.cache-bridgedb.outputs.cache-hit || 'false' }}\`"
+            echo
+            echo "Linkset workflows restore this bundle and skip downloading."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
You were right and I was wrong to wave this off — I had conflated *the existing cache is dead* (true) with *caching is not worth it* (not true, and less true as linksets multiply).

**The numbers.** The union of species across the repo is 13, totalling **3.2 GB** — comfortably inside the 10 GB per-repo cache limit. Human alone is 840 MB and is currently downloaded separately by WikiPathways, TFLink, Orphanet and ChEMBL.

**What I got wrong before.** I claimed per-species caching would need a matrix refactor because `actions/cache` cannot be called inside a bash loop. That is true only for per-species entries. A *single* bundle entry with `path: bridgedb` works with the existing loops untouched.

**How it works.** `update-bridgedb.yml` builds a bundle of every species in `wikipathways/species.tsv` (a superset of what the other linksets use), keyed on the ISO week. The weekly cadence does double duty: it picks up BridgeDb releases, and it keeps the entry alive, since GitHub evicts caches unread for 7 days. Dispatch it manually to pull a release mid-week.

The four linkset workflows restore that bundle **read-only** before building. Nothing else was needed: `fetch-bridge.sh` already returns immediately when the target is present and passes a zip test, so a cache hit turns every download into a no-op. They restore the current week's key with a `bridgedb-bundle-` prefix fallback, and on a miss they download exactly as before — a linkset run never depends on the weekly job having succeeded.

The cache this replaces was genuinely dead: it pinned `Hs_Derby_Ensembl_111` behind a hardcoded Figshare id, and nothing had restored it since the workflows moved to resolving URLs from `bridgedb/data`.

**Also fixes ChEMBL**, which appeared while I was working and still used `wget` with a spoofed Chrome user-agent — the same latent HTTP 202 bug already removed from TFLink and Orphanet.

Verified: all six workflows parse, every `run:` block passes `bash -n`, and the weekly job's species loop resolves all 13 species against a live `gene.json`. That loop needed care — `species.tsv` puts `bridgedb_species` in field 3, whereas `build/manifest.tsv` (what the linkset workflows iterate) has an extra `organism` column and puts it in field 4.