### PR TITLE
Label gene nodes with their NCBI gene symbol

### DIFF
--- a/.github/workflows/create-linkset-wikipathways.yml
+++ b/.github/workflows/create-linkset-wikipathways.yml
@@ -163,6 +163,7 @@ jobs:
             python3 scripts/qc_xgmml.py \
               --min-nodes 1 --min-edges 1 \
               --mapped-type gene --min-mapped-frac "$frac" \
+              --labelled-type gene \
               "wikipathways_${code}.xgmml"
             echo "::endgroup::"
           done < <(tail -n +2 build/manifest.tsv)
@@ -310,7 +311,7 @@ jobs:
           # items rather than joining with "; ".
           species_list=$(tail -n +2 build/manifest.tsv | cut -f3 |
             awk 'BEGIN{ORS=""} NR>1{print "; "} {print}')
-          description="<p>This dataset contains linkset networks of pathway-gene interactions from WikiPathways release ${version}, in XGMML format, for ${n_species} species: ${species_list}.</p>"
+          description="<p>This dataset contains linkset networks of pathway-gene interactions from WikiPathways release ${version}, in XGMML format, for ${n_species} species: ${species_list}.</p><p>Gene nodes are labelled with the official gene symbol from NCBI Gene (gene_info); genes NCBI has not named keep their Entrez Gene ID as the label.</p>"
 
           metadata=$(jq -n \
             --arg title "WikiPathways Linksets" \

--- a/scripts/qc_xgmml.py
+++ b/scripts/qc_xgmml.py
@@ -21,9 +21,15 @@ input id, which this catches while a non-empty `identifiers` list alone does not
 The observed fraction is always reported when --mapped-type is given, so the
 mapping yield of a new species can be measured before a threshold is chosen.
 
+--labelled-type TYPE reports what fraction of nodes of that type carry a label
+that is not simply their own id, i.e. how many got a real name rather than a
+bare identifier. It is a probe, not a gate: there is no threshold, and unlike
+--mapped-type it stays silent when a file has no nodes of that type.
+
 Usage:
     python3 qc_xgmml.py [--allow-empty] [--min-nodes N] [--min-edges N]
-                        [--mapped-type TYPE --min-mapped-frac F] FILE_OR_GLOB...
+                        [--mapped-type TYPE --min-mapped-frac F]
+                        [--labelled-type TYPE] FILE_OR_GLOB...
 
 Each positional argument is treated as a glob (literal paths work too).
 Exit code is 0 only if every matched file passes; 1 otherwise.
@@ -54,7 +60,7 @@ def _att_index(element):
 
 
 def validate_file(path, allow_empty=False, min_nodes=0, min_edges=0,
-                  mapped_type=None, min_mapped_frac=0.0):
+                  mapped_type=None, min_mapped_frac=0.0, labelled_type=None):
     """Validate one XGMML file.
 
     Returns (errors, warnings, infos, n_nodes, n_edges).
@@ -62,8 +68,10 @@ def validate_file(path, allow_empty=False, min_nodes=0, min_edges=0,
     errors = []
     warnings = []
     infos = []
-    mapped_total = 0   # nodes whose type == mapped_type
-    mapped_ok = 0      # ...of those, with >1 identifier (got cross-references)
+    mapped_total = 0     # nodes whose type == mapped_type
+    mapped_ok = 0        # ...of those, with >1 identifier (got cross-references)
+    labelled_total = 0   # nodes whose type == labelled_type
+    labelled_ok = 0      # ...of those, whose label is not just their id
 
     try:
         root = ET.parse(path).getroot()
@@ -107,10 +115,19 @@ def validate_file(path, allow_empty=False, min_nodes=0, min_edges=0,
                 errors.append(f"node '{nid}' has an empty 'identifiers' list")
         if "type" not in by_name:
             errors.append(f"node '{nid}' has no 'type' attribute")
-        elif mapped_type is not None and by_name["type"].get("value") == mapped_type:
-            mapped_total += 1
-            if n_ident > 1:
-                mapped_ok += 1
+        else:
+            node_type = by_name["type"].get("value")
+            if mapped_type is not None and node_type == mapped_type:
+                mapped_total += 1
+                if n_ident > 1:
+                    mapped_ok += 1
+            if labelled_type is not None and node_type == labelled_type:
+                labelled_total += 1
+                label_att = by_name.get("label")
+                label = (label_att.get("value") if label_att is not None
+                         else node.get("label"))
+                if label and label != nid:
+                    labelled_ok += 1
         if "label" not in by_name and node.get("label") is None:
             warnings.append(f"node '{nid}' has no 'label'")
 
@@ -161,6 +178,17 @@ def validate_file(path, allow_empty=False, min_nodes=0, min_edges=0,
                     "BridgeDb mapping may have failed"
                 )
 
+    # Report-only: no threshold. How many nodes carry a real name rather than a
+    # bare identifier varies by species far too much for one floor to be useful
+    # (measured 81% to 100%), and the pipeline that builds the labels already
+    # fails earlier, with a better message, when the source is broken.
+    if labelled_type is not None and labelled_total:
+        frac = labelled_ok / labelled_total
+        infos.append(
+            f"{labelled_ok}/{labelled_total} ({frac:.1%}) '{labelled_type}' nodes "
+            "have a label that is not just their id"
+        )
+
     return (errors, warnings, infos, n_nodes, n_edges)
 
 
@@ -174,6 +202,9 @@ def main(argv=None):
                         help="node 'type' value to report BridgeDb mapping coverage for (e.g. gene)")
     parser.add_argument("--min-mapped-frac", type=float, default=0.0,
                         help="fail unless this fraction of --mapped-type nodes have >1 identifier")
+    parser.add_argument("--labelled-type", default=None,
+                        help="node 'type' value to report label coverage for (e.g. gene); "
+                             "reports only, never fails")
     args = parser.parse_args(argv)
 
     files = []
@@ -191,7 +222,8 @@ def main(argv=None):
     for path in files:
         errors, warnings, infos, n_nodes, n_edges = validate_file(
             path, allow_empty=args.allow_empty, min_nodes=args.min_nodes, min_edges=args.min_edges,
-            mapped_type=args.mapped_type, min_mapped_frac=args.min_mapped_frac
+            mapped_type=args.mapped_type, min_mapped_frac=args.min_mapped_frac,
+            labelled_type=args.labelled_type
         )
         status = "PASS" if not errors else "FAIL"
         if errors:

--- a/wikipathways/readme.md
+++ b/wikipathways/readme.md
@@ -4,7 +4,7 @@ Pathway–gene linksets for 13 species, built from the WikiPathways GMT release.
 
 | | |
 | --- | --- |
-| Source | https://www.wikipathways.org (GMT files from https://data.wikipathways.org) |
+| Source | https://www.wikipathways.org (GMT files from https://data.wikipathways.org); gene symbols from NCBI Gene `gene_info` (public domain) |
 | License | CC BY 4.0 as deposited; WikiPathways content itself is CC0 1.0 |
 | DOI | [10.5281/zenodo.4500957](https://doi.org/10.5281/zenodo.4500957) (concept DOI, resolves to the latest version) |
 | Workflow | `.github/workflows/create-linkset-wikipathways.yml` |
@@ -18,8 +18,9 @@ Zenodo.
 
 `wp.py` resolves the release, downloads one GMT per species, and writes
 `input_<code>.txt` plus a generated `config/wp_<code>.config` for each. Genes
-enter as Entrez (`target_syscode_in=L` for every species) and BridgeDb expands
-them to Ensembl, Entrez and UniProt, plus HGNC for human.
+enter as Entrez (`target_syscode_in=L` for every species), are labelled with
+their NCBI gene symbol, and BridgeDb expands them to Ensembl, Entrez and
+UniProt, plus HGNC for human.
 
 ```bash
 python3 wikipathways/wp.py                        # all species, newest release
@@ -87,10 +88,21 @@ Accepted` and an empty body. 202 is a success code, so `wget` exits 0 and writes
 a zero-byte file — which is how the previous download failed. The script sends
 no spoofed user-agent and accepts only an explicit 200 that passes a zip test.
 
-## Known limitation: gene labels are Entrez IDs, not symbols
+## Gene labels
 
-The GMT contains only Entrez Gene IDs, so `wp.py` writes the same value into
-both the `gene_id` and `gene_symbol` columns and gene nodes are labelled with
-numbers in Cytoscape. Fixing it needs a symbol lookup after the GMT parse — NCBI
-`gene_info` maps GeneID to Symbol — or a return to the SPARQL endpoint, whose
-query returned a `GeneName` column.
+The GMT carries only Entrez Gene IDs, so `wp.py` looks each one up in that
+species' NCBI [`gene_info`](https://ftp.ncbi.nlm.nih.gov/gene/DATA/GENE_INFO/)
+file (`<ncbi_clade>/<wp_token>.gene_info.gz`, ~24 MB for all 13) and writes the
+symbol into the column the config already uses as the label. Genes NCBI has not
+named (`LOC<GeneID>`, `NEWENTRY`) keep their Entrez ID.
+
+Coverage on release 20260710 was 98.9–100% for every species except Anopheles
+(81%). A species below `MIN_SYMBOL_FRAC` (0.5) fails the run, and so does a
+failed `gene_info` download: a number-labelled linkset is exactly the defect
+this replaces, it passes every other check, and Zenodo DOIs are immutable.
+
+BridgeDb cannot supply this outside human — `M`/`R`/`Z`/`F`/`W`/`D` are
+accessions (`MGI:98834`, `WBGene00000001`), not symbols, and only `H` (HGNC) is
+a symbol. Each `.bridge` does carry a `Symbol` attribute for every species, but
+linkset-creator reads labels only from an input column, so using it would mean a
+Java/JDBC step.

--- a/wikipathways/species.tsv
+++ b/wikipathways/species.tsv
@@ -1,31 +1,41 @@
 # The species built by wp.py. This is the only place the species list lives.
 #
+# Nothing reads this file positionally except load_species(), so a new column
+# may be inserted anywhere. (build/manifest.tsv is the opposite: the workflow
+# slices it with cut/read, so columns there may only be appended.)
+#
 # code              names input_<code>.txt, config/wp_<code>.config, wikipathways_<code>.xgmml
 # wp_token          species as spelled in the GMT filename
+# ncbi_clade        directory under ftp.ncbi.nlm.nih.gov/gene/DATA/GENE_INFO/ holding
+#                   <wp_token>.gene_info.gz, the GeneID -> Symbol table used for gene
+#                   labels. NCBI publishes per-species files for a shortlist only, so
+#                   check that listing before enabling a new species.
 # bridgedb_species  species key in bridgedb/data gene.json (not derivable from wp_token)
 # syscodes_out      BridgeDb systems to expand gene ids into; H (HGNC) is human-only
 # tier              core = a missing GMT fails the run; extra = skipped; off = not built
 # min_mapped_frac   QC floor for BridgeDb cross-reference coverage
 #
-# code	wp_token	bridgedb_species	syscodes_out	tier	min_mapped_frac
-hsa	Homo_sapiens	Homo sapiens	En,H,L,S	core	0.90
-mmu	Mus_musculus	Mus musculus	En,L,S	core	0.90
-rno	Rattus_norvegicus	Rattus norvegicus	En,L,S	core	0.90
-bta	Bos_taurus	Bos taurus	En,L,S	extra	0.80
-sce	Saccharomyces_cerevisiae	Saccharomyces cerevisiae	En,L,S	extra	0.80
-cel	Caenorhabditis_elegans	Caenorhabditis elegans	En,L,S	extra	0.80
-dre	Danio_rerio	Danio rerio	En,L,S	extra	0.80
-ptr	Pan_troglodytes	Pan troglodytes	En,L,S	extra	0.80
-cfa	Canis_familiaris	Canis familiaris	En,L,S	extra	0.80
-gga	Gallus_gallus	Gallus gallus	En,L,S	extra	0.80
-dme	Drosophila_melanogaster	Drosophila melanogaster	En,L,S	extra	0.80
-ath	Arabidopsis_thaliana	Arabidopsis thaliana	En,L,S	extra	0.80
-aga	Anopheles_gambiae	Anopheles gambiae	En,L,S	extra	0.80
+# code	wp_token	ncbi_clade	bridgedb_species	syscodes_out	tier	min_mapped_frac
+hsa	Homo_sapiens	Mammalia	Homo sapiens	En,H,L,S	core	0.90
+mmu	Mus_musculus	Mammalia	Mus musculus	En,L,S	core	0.90
+rno	Rattus_norvegicus	Mammalia	Rattus norvegicus	En,L,S	core	0.90
+bta	Bos_taurus	Mammalia	Bos taurus	En,L,S	extra	0.80
+sce	Saccharomyces_cerevisiae	Fungi	Saccharomyces cerevisiae	En,L,S	extra	0.80
+cel	Caenorhabditis_elegans	Invertebrates	Caenorhabditis elegans	En,L,S	extra	0.80
+dre	Danio_rerio	Non-mammalian_vertebrates	Danio rerio	En,L,S	extra	0.80
+ptr	Pan_troglodytes	Mammalia	Pan troglodytes	En,L,S	extra	0.80
+cfa	Canis_familiaris	Mammalia	Canis familiaris	En,L,S	extra	0.80
+gga	Gallus_gallus	Non-mammalian_vertebrates	Gallus gallus	En,L,S	extra	0.80
+dme	Drosophila_melanogaster	Invertebrates	Drosophila melanogaster	En,L,S	extra	0.80
+ath	Arabidopsis_thaliana	Plants	Arabidopsis thaliana	En,L,S	extra	0.80
+aga	Anopheles_gambiae	Invertebrates	Anopheles gambiae	En,L,S	extra	0.80
 #
 # Too few pathways to be a useful linkset (counts from release 20260710).
-# Uncomment and set tier to extra once WikiPathways has more content.
-# eca	Equus_caballus	Equus caballus	En,L,S	off	0.00	5 pathways
-# pop	Populus_trichocarpa	Populus trichocarpa	En,L,S	off	0.00	5 pathways
-# ssc	Sus_scrofa	Sus scrofa	En,L,S	off	0.00	2 pathways
-# sly	Solanum_lycopersicum	Solanum lycopersicum	En,L,S	off	0.00	1 pathway
-# zma	Zea_mays	Zea mays	En,L,S	off	0.00	1 pathway
+# Uncomment and set tier to extra once WikiPathways has more content. Note that
+# NCBI has no per-species gene_info for horse, tomato or poplar (only the
+# 100-460 MB All_<clade> files), so those three need a symbol source too.
+# eca	Equus_caballus	Mammalia	Equus caballus	En,L,S	off	0.00	5 pathways, no gene_info
+# pop	Populus_trichocarpa	Plants	Populus trichocarpa	En,L,S	off	0.00	5 pathways, no gene_info
+# ssc	Sus_scrofa	Mammalia	Sus scrofa	En,L,S	off	0.00	2 pathways
+# sly	Solanum_lycopersicum	Plants	Solanum lycopersicum	En,L,S	off	0.00	1 pathway, no gene_info
+# zma	Zea_mays	Plants	Zea mays	En,L,S	off	0.00	1 pathway

--- a/wikipathways/wp.py
+++ b/wikipathways/wp.py
@@ -6,6 +6,10 @@ For every species listed in wikipathways/species.tsv this writes:
     input_<code>.txt                        tab-delimited pathway-gene pairs
     wikipathways/config/wp_<code>.config    generated from wp.config.template
 
+Gene nodes are labelled with their NCBI gene symbol, looked up per species in
+NCBI gene_info; the GMT itself carries only Entrez ids. A gene NCBI has not
+named keeps its Entrez id as the label.
+
 plus two files describing the build:
 
     build/version.txt                the WikiPathways release that was used
@@ -42,9 +46,12 @@ inputs:
 
 import argparse
 import csv
+import gzip
+import os
 import pathlib
 import re
 import sys
+import time
 
 import requests
 
@@ -70,9 +77,43 @@ MAX_RELEASE_CANDIDATES = 3
 # skipped; a 'core' species below it means something is wrong upstream.
 MIN_PATHWAYS = 5
 
+# NCBI per-species gene_info gives GeneID -> Symbol. The GMT carries no symbol,
+# so without this every gene node is labelled with a bare Entrez number. The
+# filename is the WikiPathways token for all 13 species -- including
+# Canis_familiaris, which NCBI does NOT file under Canis_lupus_familiaris -- so
+# only the clade directory differs, and it is not derivable from the token.
+NCBI_GENE_INFO_URL = "https://ftp.ncbi.nlm.nih.gov/gene/DATA/GENE_INFO"
+
+# Validated when species.tsv is read, so a typo fails before any download.
+NCBI_CLADES = frozenset({
+    "Archaea_Bacteria", "Fungi", "Invertebrates", "Mammalia",
+    "Non-mammalian_vertebrates", "Plants", "Protozoa", "Viruses",
+})
+
+# What NCBI writes for a gene it has not named. LOC<GeneID> is handled
+# separately because it embeds the gene's own id.
+PLACEHOLDER_SYMBOLS = frozenset({"-", "NEWENTRY"})
+
+# A symbol carrying any of these would corrupt the input file: csv.writer would
+# quote the field, but linkset-creator splits rows with Java String.split("\t")
+# rather than a CSV parser, so an embedded tab shifts every later column.
+UNSAFE_IN_SYMBOL = frozenset("\t\r\n\"")
+
+# Fail a species below this fraction of its genes carrying a symbol. Measured on
+# release 20260710: 100% for mmu/sce/cel/dme/ath, 98.9-99.9% elsewhere, and
+# 81.2% for aga (NCBI has named only a third of Anopheles genes). Well below the
+# worst real value, but far above the 0% of a gene_info file that downloaded but
+# was empty, truncated, or for the wrong organism.
+MIN_SYMBOL_FRAC = 0.5
+
+DOWNLOAD_ATTEMPTS = 3
+
 MANIFEST_COLUMNS = [
     "code", "wp_token", "organism", "bridgedb_species",
     "syscodes_out", "min_mapped_frac", "n_pathways", "n_rows",
+    # Append here, never insert: the workflow reads this file positionally
+    # (`cut -f3`, and `read -r code token organism bridgedb_species rest`).
+    "n_genes", "symbol_frac",
 ]
 
 INPUT_COLUMNS = [
@@ -166,14 +207,19 @@ def load_species(selected=None, path=SPECIES_TSV):
             if not line.strip() or line.lstrip().startswith("#"):
                 continue
             fields = line.rstrip("\n").split("\t")
-            if len(fields) < 6:
-                sys.exit(f"ERROR: {path}: expected 6 columns, got {len(fields)}: {line!r}")
-            code, token, bridgedb_species, syscodes_out, tier, min_frac = fields[:6]
+            if len(fields) < 7:
+                sys.exit(f"ERROR: {path}: expected 7 columns, got {len(fields)}: {line!r}")
+            (code, token, clade, bridgedb_species,
+             syscodes_out, tier, min_frac) = fields[:7]
             if tier == "off" or (only and code not in only):
                 continue
+            if clade not in NCBI_CLADES:
+                sys.exit(f"ERROR: {path}: {code} has unknown ncbi_clade {clade!r}; "
+                         f"expected one of {', '.join(sorted(NCBI_CLADES))}")
             rows.append({
                 "code": code,
                 "wp_token": token,
+                "ncbi_clade": clade,
                 "organism": token.replace("_", " "),
                 "bridgedb_species": bridgedb_species,
                 "syscodes_out": syscodes_out,
@@ -189,6 +235,106 @@ def load_species(selected=None, path=SPECIES_TSV):
         sys.exit(f"ERROR: --species names species not enabled in {path}: "
                  f"{' '.join(sorted(unknown))}")
     return rows
+
+
+def download(url, local, attempts=DOWNLOAD_ATTEMPTS):
+    """Stream url to local, reusing an existing non-empty copy.
+
+    Written to a sibling temp file and renamed only once the transfer finished,
+    so an interrupted run cannot leave a truncated file that the next run
+    happily reuses. The temp name keeps the .gz suffix so .gitignore covers it.
+    """
+    if os.path.exists(local) and os.path.getsize(local) > 0:
+        print(f"  using existing {local} (delete it to refresh)")
+        return local
+
+    tmp = f"{local[:-3]}.partial.gz" if local.endswith(".gz") else f"{local}.partial"
+    delay = 2
+    try:
+        for attempt in range(1, attempts + 1):
+            try:
+                with requests.get(url, stream=True, timeout=600) as response:
+                    if response.status_code == 404:
+                        # Not transient, so do not spend retries on it: either
+                        # the ncbi_clade is wrong, or NCBI publishes no
+                        # per-species file for this organism (it does so for a
+                        # shortlist only -- horse, tomato and poplar have none).
+                        sys.exit(f"ERROR: {url} does not exist (404). Check the "
+                                 f"ncbi_clade column against the listing at "
+                                 f"{NCBI_GENE_INFO_URL}/")
+                    response.raise_for_status()
+                    with open(tmp, "wb") as handle:
+                        for chunk in response.iter_content(chunk_size=1 << 20):
+                            handle.write(chunk)
+                os.replace(tmp, local)
+                return local
+            except requests.RequestException as error:
+                print(f"  attempt {attempt}/{attempts} failed: {error}")
+                if attempt == attempts:
+                    sys.exit(f"ERROR: could not download {url}")
+                time.sleep(delay)
+                delay *= 2
+    finally:
+        if os.path.exists(tmp):
+            os.remove(tmp)
+
+
+def usable_symbol(gene_id, symbol):
+    """True if gene_info's Symbol is a name rather than an NCBI placeholder.
+
+    NCBI never leaves Symbol empty: an unnamed gene is given LOC<GeneID>. The
+    test is equality with this row's own GeneID rather than a "LOC" prefix, so a
+    real gene whose name merely starts with LOC is never discarded.
+
+    Systematic-looking names that are NOT placeholders are deliberately kept:
+    Arabidopsis AGI codes (AT2G01050) and yeast systematic names (YCL068C) are
+    the identifiers those communities actually use.
+    """
+    if not symbol or symbol in PLACEHOLDER_SYMBOLS:
+        return False
+    if symbol == f"LOC{gene_id}":
+        return False
+    return not (UNSAFE_IN_SYMBOL & set(symbol))
+
+
+def load_symbols(species):
+    """Return {GeneID: Symbol} from this species' NCBI gene_info file.
+
+    Deliberately does NOT filter on tax_id. A per-species file also carries
+    strain and subspecies rows: the yeast file holds 6478 rows of 559292 against
+    36 of 4932, and the mouse file spans five taxa, so filtering on the nominal
+    id would discard nearly everything. Entrez GeneIDs are globally unique, so a
+    row for another taxon can never be matched by the wrong species.
+
+    gene_info columns: 0 tax_id  1 GeneID  2 Symbol  3 LocusTag  4 Synonyms ...
+    """
+    url = f"{NCBI_GENE_INFO_URL}/{species['ncbi_clade']}/{species['wp_token']}.gene_info.gz"
+    local = f"gene_info_{species['code']}.gz"
+    print(f"  symbols: {url}")
+    download(url, local)
+
+    symbols = {}
+    try:
+        with gzip.open(local, "rt", encoding="utf-8") as handle:
+            for row in csv.reader(handle, delimiter="\t"):
+                if not row or row[0].startswith("#") or len(row) < 3:
+                    continue
+                gene_id, symbol = row[1], row[2]
+                if usable_symbol(gene_id, symbol):
+                    symbols[gene_id] = symbol
+    except (OSError, EOFError, UnicodeDecodeError) as error:
+        # gzip.BadGzipFile is an OSError; a truncated file raises EOFError.
+        sys.exit(f"ERROR: cannot read {local}: {error} (delete it and re-run)")
+
+    if not symbols:
+        sys.exit(f"ERROR: {local} contains no usable gene symbols")
+    return symbols
+
+
+def symbol_coverage(pathways, symbols):
+    """Return (distinct genes, how many of them have a symbol)."""
+    genes = {gene for pathway in pathways for gene in pathway[4]}
+    return len(genes), sum(1 for gene in genes if gene in symbols)
 
 
 def parse_gmt(text):
@@ -233,7 +379,7 @@ def parse_gmt(text):
     return pathways
 
 
-def write_input(code, pathways):
+def write_input(code, pathways, symbols):
     """Write input_<code>.txt. Returns the number of pathway-gene rows."""
     out = f"input_{code}.txt"
     rows = 0
@@ -242,8 +388,10 @@ def write_input(code, pathways):
         writer.writerow(INPUT_COLUMNS)
         for name, pathway_id, version, species, genes in pathways:
             for gene in genes:
-                # The gene id doubles as the label: the GMT carries no symbol.
-                writer.writerow([name, pathway_id, len(genes), gene, gene, version, species])
+                # The GMT has no symbol; it comes from NCBI gene_info, and a
+                # gene NCBI has not named keeps its Entrez id as the label.
+                writer.writerow([name, pathway_id, len(genes), gene,
+                                 symbols.get(gene, gene), version, species])
                 rows += 1
     return rows
 
@@ -320,12 +468,23 @@ def main(argv=None):
             print(f"SKIP {message}")
             continue
 
-        n_rows = write_input(code, pathways)
+        symbols = load_symbols(species)
+        n_genes, n_symbols = symbol_coverage(pathways, symbols)
+        frac = n_symbols / n_genes
+        print(f"  {len(symbols)} symbols in gene_info; "
+              f"{n_symbols}/{n_genes} ({frac:.1%}) of this species' genes named")
+        if frac < MIN_SYMBOL_FRAC:
+            sys.exit(f"ERROR: {label}: only {n_symbols}/{n_genes} ({frac:.1%}) of genes "
+                     f"have a symbol, below the minimum of {MIN_SYMBOL_FRAC:.0%}")
+
+        n_rows = write_input(code, pathways, symbols)
         config = write_config(species, version, template)
         print(f"  {len(pathways)} pathways, {n_rows} pairs -> input_{code}.txt, {config}")
 
         species["n_pathways"] = len(pathways)
         species["n_rows"] = n_rows
+        species["n_genes"] = n_genes
+        species["symbol_frac"] = f"{frac:.4f}"
         built.append(species)
 
     if not built:


### PR DESCRIPTION
Gene nodes were labelled with bare Entrez numbers (`7157` rather than `TP53`) in Cytoscape. The GMT carries no symbols, so `wp.py` wrote the id into both the `gene_id` and `gene_symbol` columns — and `gene_symbol` is the column the config uses as the label.

**This is a display fix only.** Human gene nodes already carried the symbol in their `identifiers` list (syscode `H` expands to HGNC), so network matching in CyTargetLinker was never broken.

## Why not BridgeDb

Outside human, BridgeDb has no symbol *syscode*: `M`=MGI, `R`=RGD, `Z`=ZFIN, `F`=FlyBase, `W`=WormBase, `D`=SGD are all **accessions** (`MGI:98834`, `WBGene00000001`, `S000028457`). Only `H` (HGNC) is a symbol, and it is human-only.

Each `.bridge` *does* carry a `Symbol` attribute for all 13 species — verified against the local Derby files (`L:22059 → Trp53`, `L:851262 → TFC3`). But linkset-creator reads labels only from an input column (`GenericCreator.java:217-221`), Derby is a Java database, and `wp.py` runs before the bridges are downloaded — so using it would mean a JDBC dump step and a reordered workflow. NCBI `gene_info` is pure Python and self-contained.

## How

A new `ncbi_clade` column in `species.tsv` supplies the one part of the URL that isn't derivable. The filename is the WikiPathways token for all 13 species — including `Canis_familiaris`, which NCBI does *not* file under `Canis_lupus_familiaris`. Clades are validated against a fixed set when `species.tsv` is read, so a typo fails before a single byte is downloaded.

Two decisions worth calling out:

**No tax_id filter.** Per-species files carry strain and subspecies rows: the yeast file is 6478 rows of `559292` against 36 of `4932`, and the mouse file spans five taxa. Filtering on the nominal id would have discarded nearly everything. Entrez GeneIDs are globally unique, so a row for another taxon can never be matched by the wrong species.

**The placeholder test is equality with the row's own GeneID**, not a `LOC` prefix — so a real gene whose name happens to start with LOC is never discarded. Names that only *look* systematic are kept deliberately: Arabidopsis AGI codes (`AT2G01050`) and yeast systematic names (`YCL068C`) are the identifiers those communities actually use.

## Failure policy

A failed download, or a species below `MIN_SYMBOL_FRAC` (0.5), fails the run rather than falling back to numbers. Unlike every other failure in this pipeline, a missing symbol table produces output that passes every existing check — full node and edge counts, valid XML, complete cross-reference coverage — while being exactly the defect this removes, and Zenodo versions are immutable. Network tolerance lives in `download()`'s retry-with-backoff instead, and a 404 exits immediately rather than spending retries.

`download()` also writes to a `.partial.gz` sibling and renames only on success, so an interrupted run can't leave a truncated file that the next run happily reuses.

## Coverage (release 20260710, all 13 species built locally)

| | | | |
|---|---|---|---|
| mmu 100% | sce 100% | cel 100% | dme 100% |
| ath 100% | gga 99.9% | rno 99.8% | dre 99.8% |
| hsa 99.4% | cfa 99.0% | bta 98.9% | ptr 98.9% |
| **aga 81.2%** | | | |

Anopheles is the outlier — NCBI has named only about a third of its genes. Total download is 24 MB for all 13.

## Verification

- `7157 → TP53`, `851818 → HEM1` confirmed end to end, including in the built XGMML (`<att name="label" value="TP53">`).
- **Only column 5 changed**: `diff` of columns 1-4,6,7 against the previous inputs is empty for hsa/sce/ath — row set, ordering, ids, version and species strings are byte-identical.
- Zero `LOC<id>`/`NEWENTRY`/`-` placeholders leaked; 133 AGI codes and 3 yeast systematic names correctly kept.
- Output structure matches the known-good published 2022 linkset exactly (`<node id="3640" label="3640">` with the symbol in the `label` att — the XML `label=` attribute has always been the id).
- Idempotent re-run reuses the cached file and produces byte-identical output; a truncated cache fails cleanly rather than silently yielding a partial symbol map.
- All three positional manifest consumers still work after appending `n_genes`/`symbol_frac`.

## Also

`qc_xgmml.py` gains `--labelled-type`, a **report-only** probe (no threshold) that reports what fraction of nodes carry a label that isn't just their id — the end-to-end confirmation that the label survived the jar. Deliberately no `--min-labelled-frac`: the 81–100% spread means a global floor either catches nothing `MIN_SYMBOL_FRAC` didn't, or fails Anopheles forever over NCBI's naming completeness.

The Zenodo description now credits NCBI Gene as the label source. NCBI Gene is a US Government public-domain work, so the CC BY 4.0 deposit is unaffected.

**Note:** the workspace-level `CLAUDE.md` documents `species.tsv`'s columns and will drift until updated separately.