### PR TITLE
Move the workflows onto Node.js 24 action versions

### DIFF
--- a/.github/workflows/Chembl_MoA.yml
+++ b/.github/workflows/Chembl_MoA.yml
@@ -33,16 +33,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "11"
 
       - name: Restore linkset-creator jar from cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         id: cache-jar
         with:
           path: ./linkset-creator-v2.0.jar
@@ -55,7 +55,7 @@ jobs:
             https://github.com/CyTargetLinker/linksetCreator/releases/download/v2.0/linkset-creator-v2.0.jar
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.x"
 
@@ -85,7 +85,7 @@ jobs:
       # returns immediately; on a miss it downloads as usual, so a linkset run
       # never depends on the weekly job having succeeded.
       - name: Restore the BridgeDb bundle
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: bridgedb
           # The bundle key is content-derived and owned by update-bridgedb, so
@@ -143,7 +143,7 @@ jobs:
             "ChEMBL_MechanismOfAction.xgmml"
 
       - name: Upload linkset artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ChEMBL-MechanismOfAction-linkset
           path: ChEMBL_MechanismOfAction.xgmml

--- a/.github/workflows/Create_OrphanetLinkset.yml
+++ b/.github/workflows/Create_OrphanetLinkset.yml
@@ -36,16 +36,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "11"
 
       - name: Restore linkset-creator jar from cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         id: cache-jar
         with:
           path: ./linkset-creator-v2.0.jar
@@ -58,7 +58,7 @@ jobs:
             https://github.com/CyTargetLinker/linksetCreator/releases/download/v2.0/linkset-creator-v2.0.jar
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.x"
 
@@ -76,7 +76,7 @@ jobs:
       # returns immediately; on a miss it downloads as usual, so a linkset run
       # never depends on the weekly job having succeeded.
       - name: Restore the BridgeDb bundle
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: bridgedb
           # The bundle key is content-derived and owned by update-bridgedb, so
@@ -134,7 +134,7 @@ jobs:
             "Orphanet.xgmml"
 
       - name: Upload linkset artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Orphanet-linkset
           path: Orphanet.xgmml

--- a/.github/workflows/create-linkset-tflink.yml
+++ b/.github/workflows/create-linkset-tflink.yml
@@ -41,16 +41,16 @@ jobs:
     steps:
 
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '11'
 
       - name: Restore linkset-creator jar from cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         id: cache-jar
         with:
           path: ./linkset-creator-v2.0.jar
@@ -63,7 +63,9 @@ jobs:
             https://github.com/CyTargetLinker/linksetCreator/releases/download/v2.0/linkset-creator-v2.0.jar
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.x"
 
       - name: Install dependencies with pip
         run: pip3 install pandas requests
@@ -79,7 +81,7 @@ jobs:
       # returns immediately; on a miss it downloads as usual, so a linkset run
       # never depends on the weekly job having succeeded.
       - name: Restore the BridgeDb bundle
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: bridgedb
           # The bundle key is content-derived and owned by update-bridgedb, so
@@ -132,7 +134,7 @@ jobs:
           ls -la tflink_*.xgmml
 
       - name: Upload linkset artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: tflink-linksets
           path: tflink_*.xgmml

--- a/.github/workflows/create-linkset-wikipathways.yml
+++ b/.github/workflows/create-linkset-wikipathways.yml
@@ -52,10 +52,10 @@ jobs:
     steps:
 
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Restore linkset-creator jar from cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         id: cache-jar
         with:
           path: ./linkset-creator-v2.0.jar
@@ -68,13 +68,15 @@ jobs:
             https://github.com/CyTargetLinker/linksetCreator/releases/download/v2.0/linkset-creator-v2.0.jar
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "11"
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.x"
 
       - name: Install dependencies
         run: pip3 install requests
@@ -111,7 +113,7 @@ jobs:
       # returns immediately; on a miss it downloads as usual, so a linkset run
       # never depends on the weekly job having succeeded.
       - name: Restore the BridgeDb bundle
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: bridgedb
           # The bundle key is content-derived and owned by update-bridgedb, so
@@ -176,7 +178,7 @@ jobs:
           echo "$built linkset(s) built and validated"
 
       - name: Upload linkset artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wikipathways-linksets-${{ env.WP_RELEASE }}
           path: |

--- a/.github/workflows/qc-xgmml.yml
+++ b/.github/workflows/qc-xgmml.yml
@@ -63,14 +63,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.x"
 
       - name: Download artifact to validate
         if: ${{ inputs.artifact != '' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.artifact }}
           path: qc-input

--- a/.github/workflows/update-bridgedb.yml
+++ b/.github/workflows/update-bridgedb.yml
@@ -54,10 +54,10 @@ jobs:
     steps:
 
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Cache linkset-creator jar
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         id: cache-linkset-creator-jar
         with:
           path: ./linkset-creator-v2.0.jar
@@ -129,7 +129,7 @@ jobs:
           cat species-urls.tsv
 
       - name: Restore or create the BridgeDb bundle
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         id: cache-bridgedb
         with:
           path: bridgedb
@@ -178,7 +178,7 @@ jobs:
           echo "Metabolites: $file"
 
       - name: Restore or create the metabolite cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         id: cache-metabolites
         with:
           path: bridgedb-metabolites


### PR DESCRIPTION
Fixes #10.

The deprecation warning in the issue is the Node.js 20 runtime notice: the runner forced Node.js 24 as the default on 16 June 2026 and **removes Node.js 20 on 16 September 2026**, at which point these workflows stop running. Every action in the repo was still on a Node.js 20 major.

All 31 `uses:` references are bumped to the current major, each of which declares `runs.using: node24`:

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | v4 | v7 |
| `actions/setup-java` | v4 | v5 |
| `actions/setup-python` | v5 | v7 |
| `actions/cache` (and `/restore`) | v4 | v6 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |

### Breaking changes checked, none apply
- **checkout v7** blocks checking out fork PRs under `pull_request_target` / `workflow_run`. No workflow here uses either trigger — all are `workflow_dispatch`, plus a `schedule` on the BridgeDb job and `workflow_call` on QC.
- **setup-python v7** removed the `pip-install` input. Not used anywhere.
- **download-artifact v8** enforces hash checks and skips decompressing non-zipped downloads. The only consumer is `qc-xgmml.yml`, reading artifacts written by `upload-artifact@v7` with default (archived) uploads.
- **cache v6** may miss existing entries once as the caches repopulate. That is already the designed behaviour — the restore steps fall through to a normal download on a miss, so a linkset run never depends on a warm cache.

### Also included
The same runs raised a second annotation, `The python-version input is not set`. Three workflows called `setup-python` with no inputs and silently used whatever Python was on the runner `PATH`; they now pin `python-version: "3.x"`, matching what `Chembl_MoA.yml` and `Create_OrphanetLinkset.yml` already did.

### Verification
All six workflow files parse as YAML and no `uses:` reference remains on an old major. The workflows are `workflow_dispatch`, so nothing runs automatically on this PR — worth manually triggering the WikiPathways build once after merge to confirm a clean run.