### PR TITLE
Make the linkset status list accurate and reachable

### DIFF
--- a/LinksetStatusList.md
+++ b/LinksetStatusList.md
@@ -1,22 +1,64 @@
-# Status: in production
+# Linkset status
 
+Which source databases this repository automates, and how far each one has got.
 
-# Status: in progress
-* WikiPathways (version updating in the Action needs to be fixed)
-* TFLink (Zenodo publishing in progress)
-* ChEMBL (no action yet)
-* OrphanNet (workflow script under development)
+Status here describes the **automation pipeline**, not whether a CyTargetLinker
+linkset exists at all. Several databases below already have linksets on the
+[CyTargetLinker website](https://cytargetlinker.github.io/pages/linksets) that
+were built by hand before this repository existed; they still appear as
+candidates because the build is not yet automated.
 
-# Status: wishlist
-* DISEASES database (disease-gene associations: https://diseases.jensenlab.org/Downloads)
-* CTD database (chemical-target, chemical-diseases, chemical-pathway associations: https://ctdbase.org/downloads)
-* TTRUST (transcription factor-target interactions: https://www.grnpedia.org/trrust/)
-* Reactome (pathway-gene associations: https://reactome.org/)
-* CollecTRI (transcription factor-target interactions: https://github.com/saezlab/collecTRI)
+Deposit details — persistent DOIs, licenses and per-resource build notes — live
+in the resource table in [`README.md`](README.md#linkset-resources) rather than
+being repeated here.
 
-# Status: license limitation
-_(aim to provide script for LinkSet creation but not redistribute data files)_
-* DrugBank
-* DisGenNet
+## In production
 
+The workflow runs green and the output is deposited under a persistent DOI.
 
+| Resource | Interactions | Workflow |
+| --- | --- | --- |
+| [WikiPathways](https://www.wikipathways.org) | pathway–gene, 13 species | [`create-linkset-wikipathways.yml`](.github/workflows/create-linkset-wikipathways.yml) |
+| [TFLink](https://tflink.net) | transcription factor–target gene, 5 species | [`create-linkset-tflink.yml`](.github/workflows/create-linkset-tflink.yml) |
+
+## Automated, not yet deposited
+
+The workflow exists and the linkset builds, but nothing is published under a DOI
+yet and the deposit license is still undecided.
+
+| Resource | Interactions | Workflow | Outstanding |
+| --- | --- | --- | --- |
+| [Orphanet](https://www.orphadata.com/) | gene–rare disease | [`Create_OrphanetLinkset.yml`](.github/workflows/Create_OrphanetLinkset.yml) | Zenodo deposit; [`Orphanet/readme.md`](Orphanet/readme.md) is still a placeholder |
+| [ChEMBL](https://www.ebi.ac.uk/chembl/) | compound–protein target (mechanism of action) | [`Chembl_MoA.yml`](.github/workflows/Chembl_MoA.yml) | workflow is not passing yet; Zenodo deposit; [`CHEMBL/readme.md`](CHEMBL/readme.md) is still a placeholder |
+
+## Candidates
+
+Databases we would like to automate. No workflow yet.
+
+| Database | Interactions | Source |
+| --- | --- | --- |
+| DISEASES | disease–gene associations | https://diseases.jensenlab.org/Downloads |
+| CTD | chemical–target, chemical–disease, chemical–pathway | https://ctdbase.org/downloads |
+| TRRUST | transcription factor–target | https://www.grnpedia.org/trrust/ |
+| Reactome | pathway–gene | https://reactome.org/ |
+| CollecTRI | transcription factor–target | https://github.com/saezlab/collecTRI |
+
+## License limitation
+
+Redistributing the built linkset is not permitted by the upstream license. The
+aim is to provide a script that lets users build the linkset themselves from
+their own copy of the source data, without shipping the data files.
+
+| Database | Interactions | Source |
+| --- | --- | --- |
+| DrugBank | drug–target | https://go.drugbank.com/ |
+| DisGeNET | gene–disease associations | https://www.disgenet.org/ |
+
+## Supporting workflows
+
+Not linksets themselves, but part of the build:
+
+- [`update-bridgedb.yml`](.github/workflows/update-bridgedb.yml) — refreshes the
+  cached BridgeDb identifier-mapping bundle that every linkset build restores.
+- [`qc-xgmml.yml`](.github/workflows/qc-xgmml.yml) — validates a built XGMML
+  linkset; callable from another workflow or triggered manually.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Under construction: This repo automatically generates CyTargetLinker linksets fr
 **This list is still being extended.** The resources below are the ones
 covered so far; more are being added as they are automated, and the table is
 updated once a resource is built and deposited.
+[`LinksetStatusList.md`](LinksetStatusList.md) tracks how far each resource has
+got, and which databases are still candidates for automation.
 
 | Resource | Details | Persistent DOI | License |
 | --- | --- | --- | --- |


### PR DESCRIPTION
Closes #12.

`LinksetStatusList.md` already existed, but it was not usable as the overview the issue asks for: **nothing in the repository linked to it** (grepped every `.md` and `.yml` — zero references), and its contents had drifted away from what the workflows actually do.

### Stale entries corrected

| Said | Actually |
| --- | --- |
| `Status: in production` was empty | WikiPathways and TFLink are both deposited under a concept DOI |
| TFLink — "Zenodo publishing in progress" | DOI `10.5281/zenodo.21804828` was recorded in the README earlier today (`aeea3be`) |
| ChEMBL — "no action yet" | `Chembl_MoA.yml` exists and runs, though it is not passing yet |
| WikiPathways — "version updating in the Action needs to be fixed" | the pipeline resolves the release and generates its configs on every run |
| OrphanNet / TTRUST / DisGenNet | Orphanet / TRRUST / DisGeNET |

Statuses were checked against run history rather than assumed: WikiPathways, TFLink and Orphanet are green; ChEMBL last completed run failed.

### Changes

- Split the old "in progress" bucket into **in production** (green *and* deposited under a DOI) and **automated, not yet deposited**. That is the distinction that matters to someone looking for a citable linkset.
- Every row now carries the interaction type, a link to the source database, and a link to the workflow that owns it.
- Named the supporting `update-bridgedb.yml` and `qc-xgmml.yml` workflows, which are part of the build but are not linksets.
- Stated explicitly that status here means *automation* status. Several candidate databases (CTD, DrugBank) already have hand-built linksets on the website, and the old list read as if they did not exist.
- Linked the document from the README, so it is reachable.

### Avoiding a repeat

The drift happened because deposit facts lived in two places. DOIs, licenses and per-resource build notes now stay in the README resource table and are referenced from the status list rather than duplicated, so the two cannot contradict each other again.

All relative links in both files were checked to resolve.