### PR TITLE
Fix silent truncation and gene mapping in the ChEMBL linkset

### DIFF
--- a/.github/workflows/Chembl_MoA.yml
+++ b/.github/workflows/Chembl_MoA.yml
@@ -139,7 +139,8 @@ jobs:
             --min-nodes 1 \
             --min-edges 1 \
             --mapped-type gene \
-            --min-mapped-frac 0.8 \
+            --min-mapped-frac 0.9 \
+            --labelled-type gene \
             "ChEMBL_MechanismOfAction.xgmml"
 
       - name: Upload linkset artifact

--- a/CHEMBL/CHEMBL_MoA.py
+++ b/CHEMBL/CHEMBL_MoA.py
@@ -1,6 +1,8 @@
 from chembl_webresource_client.new_client import new_client
 from chembl_webresource_client.settings import Settings
 import pandas as pd
+import re
+import sys
 from datetime import datetime
 
 Settings.Instance().TIMEOUT = 60
@@ -118,16 +120,17 @@ def download_all_mechanism_data(limit_compounds=None, human_only=False, tqdm_cla
                             try:
                                 target_data = target.get(target_id)
                                 if target_data:
-                                    uniprot_ids  = []
-                                    gene_symbols = []  # from target_component_synonyms GENE_SYMBOL
-                                    hgnc_ids     = []  # from target_component_xrefs HGNC
+                                    components = []
 
                                     for component in target_data.get('target_components', []) or []:
+                                        symbol  = ''
+                                        hgnc    = ''
+                                        uniprot = component.get('accession', '') or ''
 
                                         # ── Gene symbol: confirmed key is target_component_synonyms ──
                                         for syn in component.get('target_component_synonyms', []) or []:
                                             if syn.get('syn_type') == 'GENE_SYMBOL':
-                                                gene_symbols.append(syn.get('component_synonym', ''))
+                                                symbol = syn.get('component_synonym', '') or ''
                                                 break  # one gene symbol per component
 
                                         # ── xrefs: UniProt and HGNC ──
@@ -135,23 +138,28 @@ def download_all_mechanism_data(limit_compounds=None, human_only=False, tqdm_cla
                                             src   = xref.get('xref_src_db', '')
                                             xid   = xref.get('xref_id', '')
                                             xname = xref.get('xref_name', '')
-                                            if src == 'UniProt':
-                                                uniprot_ids.append(xid)
+                                            if src == 'UniProt' and not uniprot:
+                                                uniprot = xid
                                             elif src == 'HGNC':
-                                                hgnc_ids.append(xid)
+                                                hgnc = xid
                                                 # xref_name is the gene symbol e.g. "CA1"
                                                 # use as fallback if target_component_synonyms was empty
-                                                if xname and xname not in gene_symbols:
-                                                    gene_symbols.append(xname)
+                                                if xname and not symbol:
+                                                    symbol = xname
+
+                                        if symbol or hgnc:
+                                            components.append({
+                                                'uniprot_accessions': uniprot,
+                                                'gene_symbol'       : symbol,
+                                                'hgnc_id'           : hgnc,
+                                            })
 
                                     target_info = {
                                         'target_chembl_id'  : target_id,
                                         'target_name'       : target_data.get('pref_name', ''),
                                         'target_type'       : target_data.get('target_type', ''),
                                         'target_organism'   : target_data.get('organism', ''),
-                                        'uniprot_accessions': ';'.join(filter(None, uniprot_ids)),
-                                        'gene_symbol'       : ';'.join(filter(None, gene_symbols)),
-                                        'hgnc_id'           : ';'.join(filter(None, hgnc_ids)),
+                                        'components'        : components,
                                     }
                                     target_cache[target_id] = target_info
 
@@ -161,9 +169,7 @@ def download_all_mechanism_data(limit_compounds=None, human_only=False, tqdm_cla
                                     'target_name'       : '',
                                     'target_type'       : '',
                                     'target_organism'   : mechanism_data.get('target_organism', ''),
-                                    'uniprot_accessions': '',
-                                    'gene_symbol'       : '',
-                                    'hgnc_id'           : '',
+                                    'components'        : [],
                                 }
                                 target_cache[target_id] = target_info
 
@@ -196,15 +202,22 @@ def download_all_mechanism_data(limit_compounds=None, human_only=False, tqdm_cla
                         'target_name'        : target_info.get('target_name', ''),
                         'target_type'        : target_info.get('target_type', ''),
                         'target_organism'    : target_info.get('target_organism', mechanism_data.get('target_organism', '')),
-                        'uniprot_accessions' : target_info.get('uniprot_accessions', ''),
-                        'gene_symbol'        : target_info.get('gene_symbol', ''),
-                        'hgnc_id'            : target_info.get('hgnc_id', ''),
+                        'uniprot_accessions' : '',
+                        'gene_symbol'        : '',
+                        'hgnc_id'            : '',
                         # ── References ────────────────────────────────────────────
                         'ref_id'             : mechanism_refs[0].get('ref_id', '')   if mechanism_refs else '',
                         'ref_type'           : mechanism_refs[0].get('ref_type', '') if mechanism_refs else '',
                         'ref_url'            : mechanism_refs[0].get('ref_url', '')  if mechanism_refs else '',
                     }
-                    all_data.append(record)
+
+                    # one row per target component; see CHEMBL/readme.md
+                    for component in (target_info.get('components') or [{}]):
+                        row = dict(record)
+                        row['uniprot_accessions'] = component.get('uniprot_accessions', '')
+                        row['gene_symbol']        = component.get('gene_symbol', '')
+                        row['hgnc_id']            = component.get('hgnc_id', '')
+                        all_data.append(row)
 
                 except Exception:
                     continue
@@ -218,7 +231,13 @@ def download_all_mechanism_data(limit_compounds=None, human_only=False, tqdm_cla
         return None
 
     df = pd.DataFrame(all_data)
-    df_unique = df.drop_duplicates(subset=['mechanism_id'])
+    df_unique = df.drop_duplicates(subset=['mechanism_id', 'gene_symbol', 'hgnc_id'])
+
+    # Rows must stay full width for the jar's split(); see CHEMBL/readme.md.
+    df_unique = df_unique.map(
+        lambda v: re.sub(r'[\r\n\t]+', ' ', v).strip() if isinstance(v, str) else v
+    )
+    df_unique['row_end'] = '.'
 
     filename = 'input.txt'
     df_unique.to_csv(filename, index=False, sep='\t')
@@ -258,12 +277,19 @@ if __name__ == "__main__":
             def __exit__(self, *args): print(f"  {self.desc}: Complete")
         tqdm_class = SimpleTqdm
 
+    # --limit N caps the compounds fetched, for a smoke test.
+    limit = None
+    if '--limit' in sys.argv:
+        limit = int(sys.argv[sys.argv.index('--limit') + 1])
+        print(f"SMOKE TEST: limiting to {limit} compounds")
+
     total = get_all_mechanisms_count()
     if not total:
         print("Could not get count. Exiting.")
         exit()
 
-    data = download_all_mechanism_data(human_only=True, tqdm_class=tqdm_class)
+    data = download_all_mechanism_data(human_only=True, limit_compounds=limit,
+                                       tqdm_class=tqdm_class)
     if data is not None:
         print(f"\nDone! End time: {datetime.now()}")
     else:

--- a/CHEMBL/chembl_human_MoA.config
+++ b/CHEMBL/chembl_human_MoA.config
@@ -8,10 +8,10 @@ interaction_type=compound targeting protein/gene
 source_id_column=0
 source_type=chemical compound
 source_label_column=1
-target_id_column=22
+target_id_column=23
 target_type=gene
 target_bridgedb=bridgedb/hsa.bridge
-target_syscode_in=H
+target_syscode_in=Hac
 target_syscodes_out=L,En,H,S
 target_label_column=22
 

--- a/CHEMBL/readme.md
+++ b/CHEMBL/readme.md
@@ -1,1 +1,33 @@
-Placeholder for notes and information on this specific linkset automation
+# ChEMBL mechanism-of-action linkset
+
+`CHEMBL_MoA.py` pulls human drug mechanism-of-action records from ChEMBL and writes
+`input.txt`; `chembl_human_MoA.config` turns it into a compound → gene linkset.
+
+Smoke test without the full fetch:
+
+```bash
+python3 CHEMBL/CHEMBL_MoA.py --limit 40
+```
+
+## Gotchas
+
+**Rows must stay full width.** linkset-creator v2.0 reads rows with Java's
+`String.split("\t")`, which drops trailing empty fields and ignores quoting. A value
+containing a newline, or an empty final column, gives a short row; the jar throws
+`ArrayIndexOutOfBoundsException`, catches it internally and **exits 0 having
+truncated the linkset there**. On 2026-08-05 that silently cut the output to 757 of
+7561 rows. Hence the whitespace collapsing and the constant `row_end` column. The
+only symptom in QC is a single edge with no `datasource`.
+
+**The gene id is an HGNC accession, syscode `Hac`.** Column 23 holds `HGNC:1381`, so
+`H` (HGNC symbol) and `L` (Entrez Gene) both map nothing. Measured over the full
+dataset: `Hac` maps 99.8% and gives each gene node its symbol as label; column 22
+with `H` maps 84.7% and leaves every label equal to its own id.
+
+**One row per target component.** A ChEMBL target may be a protein complex: the
+GABA-B receptor is GABBR1 plus GABBR2. Joining them into one `GABBR1;GABBR2` cell
+creates a gene node that matches nothing, which is what capped mapping at ~85%.
+Each component gets its own row instead, so a row is identified by `mechanism_id`
+**plus** the gene, not `mechanism_id` alone. Components must be read one at a time —
+zipping separate symbol and HGNC lists misaligns them, because a component can have
+a symbol but no HGNC id. Keeping only the first component would cost ~6900 edges.


### PR DESCRIPTION
Today's ChEMBL runs failed QC, and lowering `--min-mapped-frac` to 0.8 could not
have helped: three separate faults were in play, and only one of them was about
the threshold.

## Rows were losing their trailing fields

linkset-creator v2.0 reads rows with Java's `String.split("\t")`, which drops
trailing empty fields and ignores quoting. The first row with an empty `ref_url`,
or any value containing a newline, produced a short array; the jar threw
`ArrayIndexOutOfBoundsException` inside `setEdgeAttributes`, caught it in its own
outer handler and **exited 0 having stopped reading there**.

```
SEVERE: Could not convert file to RegIN: Index 26 out of bounds for length 26
```

The first such row is 758 of 7561, and the run published 757 nodes. The only
visible symptom was QC reporting a single edge with no `datasource`, since
`datasource` is assigned *after* the attribute loop that threw. That error is
unconditional, which is why the 0.8 re-run failed too.

Fixed by collapsing embedded whitespace and adding a constant `row_end` column.

## Complex targets were unmappable

A ChEMBL target may be a protein complex — the GABA-B receptor is GABBR1 plus
GABBR2. Joining components into one `GABBR1;GABBR2` cell creates a gene node that
matches nothing in BridgeDb, and is biologically neither gene. This hit 20.4% of
rows and capped mapping near 85% whichever identifier column was used.

Each component now gets its own row. Note `drop_duplicates` had to widen to the
mechanism **plus** the gene — keyed on the mechanism alone it would collapse every
complex straight back to one gene, leaving the change applied in the code and
absent from the output.

## The gene identifier had the wrong system code

Column 23 holds an HGNC *accession* (`HGNC:1381`), so neither `L` (Entrez Gene)
nor `H` (HGNC symbol) matches. `Hac` does. Moving the id to column 23 was the
right call; only the syscode was wrong.

Measured over the full 7561-mechanism dataset:

| config | nodes | edges | mapped | labels |
|---|---|---|---|---|
| today's runs | 757 | 846 | 0–84.5% | fail |
| col22 `H` | 7764 | 18297 | 84.7% | none (label = id) |
| **col23 `Hac`** | **7487** | **12668** | **99.8%** | **100%** |

So `--min-mapped-frac` returns to 0.9, with the `--labelled-type gene` probe
reported alongside.

## Testing

Verified end-to-end against the real `hsa.bridge`, using a new `--limit N` flag
that caps the compounds fetched so the pipeline runs in minutes:

```
rows 303 / 85 unique mechanisms (25 span >1 row), 0 ';' left
304 lines x 28 fields, 0 SEVERE
PASS (198 nodes, 159 edges) — 98.6% mapped, 100% labelled, exit 0
```

## Follow-ups, not in this PR

- ChEMBL depositions predating the `datasource` check may have been truncated the
  same way. Zenodo DOIs are immutable, so it is worth confirming.
- The real defect is in linkset-creator: `split("\t", -1)` would fix it for every
  resource, not just this one.
- Preprocessing spends ~1h in CI on ~6000 sequential `molecule.get()` calls. It is
  fast locally only because `CACHING = True` finds a warm cache. Bulk `__in`
  queries fetch the same data in minutes.