### PR TITLE
Resolve the ChEMBL release at run time instead of pinning it

### DIFF
--- a/.github/workflows/Chembl_MoA.yml
+++ b/.github/workflows/Chembl_MoA.yml
@@ -129,7 +129,7 @@ jobs:
           java \
             -Dfile.encoding=UTF-8 \
             -jar linkset-creator-v2.0.jar \
-            -c "CHEMBL/chembl_human_MoA.config" \
+            -c "CHEMBL/config/chembl_human_MoA.config" \
             -i "input.txt" \
             -o "ChEMBL_MechanismOfAction.xgmml"
 
@@ -155,11 +155,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          version=$(sed -n 's/^version[[:space:]]*=[[:space:]]*//p' \
-            CHEMBL/chembl_human_MoA.config | head -n 1)
+          version=$(cat build/version.txt)
 
           if [ -z "$version" ]; then
-            echo "Could not find version in CHEMBL/chembl_human_MoA.config"
+            echo "build/version.txt is empty; CHEMBL_MoA.py did not resolve a release"
             exit 1
           fi
 

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ other.json
 # their .config.template files (never hand-edited).
 wikipathways/config/
 reactome/config/
+CHEMBL/config/
 
 # Reactome's pathway-gene table, downloaded by reactome.py.
 NCBI2Reactome.txt

--- a/CHEMBL/CHEMBL_MoA.py
+++ b/CHEMBL/CHEMBL_MoA.py
@@ -1,13 +1,47 @@
 from chembl_webresource_client.new_client import new_client
 from chembl_webresource_client.settings import Settings
 import pandas as pd
+import pathlib
 import re
+import requests
 import sys
 from datetime import datetime
+
+# The release is resolved at run time rather than pinned in the config: the
+# client always fetches whatever ChEMBL is serving now, so a hand-edited version
+# silently mislabels the linkset as soon as ChEMBL releases.
+CHEMBL_STATUS_URL = "https://www.ebi.ac.uk/chembl/api/data/status.json"
+CONFIG_TEMPLATE = "CHEMBL/chembl_human_MoA.config.template"
+CONFIG_OUT = "CHEMBL/config/chembl_human_MoA.config"
+BUILD_DIR = "build"
 
 Settings.Instance().TIMEOUT = 60
 Settings.Instance().CACHING = True
 Settings.Instance().CONCURRENT_SIZE = 20
+
+
+def resolve_version():
+    """Return the ChEMBL release the API is currently serving, e.g. ChEMBL_37."""
+    response = requests.get(CHEMBL_STATUS_URL, timeout=60)
+    response.raise_for_status()
+    version = (response.json().get('chembl_db_version') or '').strip()
+    if not version:
+        sys.exit(f"ERROR: no chembl_db_version at {CHEMBL_STATUS_URL}")
+    return version
+
+
+def write_config(version):
+    """Generate the linkset-creator config for this release."""
+    text = pathlib.Path(CONFIG_TEMPLATE).read_text(encoding='utf-8').format(version=version)
+    # ConfigFileReader keeps only lines splitting into exactly two parts on '=',
+    # discarding the rest as an invalid attribute.
+    for line in text.splitlines():
+        if line.strip() and line.count('=') != 1:
+            sys.exit(f"ERROR: generated config line is not a single key=value pair: {line!r}")
+    out = pathlib.Path(CONFIG_OUT)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(text, encoding='utf-8')
+    return out
 
 
 def get_all_mechanisms_count():
@@ -211,7 +245,7 @@ def download_all_mechanism_data(limit_compounds=None, human_only=False, tqdm_cla
                         'ref_url'            : mechanism_refs[0].get('ref_url', '')  if mechanism_refs else '',
                     }
 
-                    # one row per target component; see CHEMBL/readme.md
+                    # one row per target component
                     for component in (target_info.get('components') or [{}]):
                         row = dict(record)
                         row['uniprot_accessions'] = component.get('uniprot_accessions', '')
@@ -233,7 +267,7 @@ def download_all_mechanism_data(limit_compounds=None, human_only=False, tqdm_cla
     df = pd.DataFrame(all_data)
     df_unique = df.drop_duplicates(subset=['mechanism_id', 'gene_symbol', 'hgnc_id'])
 
-    # Rows must stay full width for the jar's split(); see CHEMBL/readme.md.
+    # Keep rows full width: the jar splits on tabs and drops trailing empties.
     df_unique = df_unique.map(
         lambda v: re.sub(r'[\r\n\t]+', ' ', v).strip() if isinstance(v, str) else v
     )
@@ -291,6 +325,10 @@ if __name__ == "__main__":
     data = download_all_mechanism_data(human_only=True, limit_compounds=limit,
                                        tqdm_class=tqdm_class)
     if data is not None:
+        version = resolve_version()
+        pathlib.Path(BUILD_DIR).mkdir(exist_ok=True)
+        pathlib.Path(BUILD_DIR, "version.txt").write_text(version + "\n", encoding='utf-8')
+        print(f"ChEMBL release {version} -> {write_config(version)}")
         print(f"\nDone! End time: {datetime.now()}")
     else:
         print("Download failed.")

--- a/CHEMBL/chembl_human_MoA.config.template
+++ b/CHEMBL/chembl_human_MoA.config.template
@@ -1,6 +1,6 @@
 name=chembl_MechanismOfAction
 organism=Homo sapiens
-version=Chembl_35.0
+version={version}
 source_columns=0,1,2,3,4,5,6
 target_columns=17,18,19,20,21,22,23
 edge_columns=7,8,9,10,11,12,13,14,15,16,24,25,26

--- a/CHEMBL/readme.md
+++ b/CHEMBL/readme.md
@@ -1,33 +1,49 @@
 # ChEMBL mechanism-of-action linkset
 
-`CHEMBL_MoA.py` pulls human drug mechanism-of-action records from ChEMBL and writes
-`input.txt`; `chembl_human_MoA.config` turns it into a compound → gene linkset.
+Compound → gene linkset for human, built from ChEMBL drug mechanism-of-action
+records.
 
-Smoke test without the full fetch:
+| | |
+| --- | --- |
+| Source | https://www.ebi.ac.uk/chembl/ (via `chembl_webresource_client`) |
+| License | CC BY-SA 3.0 |
+| DOI | not yet deposited |
+| Workflow | `.github/workflows/Chembl_MoA.yml` |
+| Species | human |
+
+## How it works
+
+`CHEMBL_MoA.py` pulls human mechanism records and writes `input.txt`,
+`build/version.txt` and a generated `config/chembl_human_MoA.config`. Genes enter
+as HGNC accessions (`target_syscode_in=Hac`), are labelled with their gene
+symbol, and BridgeDb expands them to Entrez, Ensembl, HGNC and UniProt.
 
 ```bash
-python3 CHEMBL/CHEMBL_MoA.py --limit 40
+python3 CHEMBL/CHEMBL_MoA.py                 # full build
+python3 CHEMBL/CHEMBL_MoA.py --limit 40      # smoke test, minutes not an hour
 ```
 
-## Gotchas
+A full run takes about an hour in CI. The client caches responses, so a local
+re-run is much faster than the first one.
 
-**Rows must stay full width.** linkset-creator v2.0 reads rows with Java's
-`String.split("\t")`, which drops trailing empty fields and ignores quoting. A value
-containing a newline, or an empty final column, gives a short row; the jar throws
-`ArrayIndexOutOfBoundsException`, catches it internally and **exits 0 having
-truncated the linkset there**. On 2026-08-05 that silently cut the output to 757 of
-7561 rows. Hence the whitespace collapsing and the constant `row_end` column. The
-only symptom in QC is a single edge with no `datasource`.
+## Targets
 
-**The gene id is an HGNC accession, syscode `Hac`.** Column 23 holds `HGNC:1381`, so
-`H` (HGNC symbol) and `L` (Entrez Gene) both map nothing. Measured over the full
-dataset: `Hac` maps 99.8% and gives each gene node its symbol as label; column 22
-with `H` maps 84.7% and leaves every label equal to its own id.
+A ChEMBL target may be a protein complex — the GABA-B receptor is GABBR1 plus
+GABBR2 — so each target component becomes its own compound → gene row. A row is
+therefore identified by `mechanism_id` **plus** the gene, not `mechanism_id`
+alone.
 
-**One row per target component.** A ChEMBL target may be a protein complex: the
-GABA-B receptor is GABBR1 plus GABBR2. Joining them into one `GABBR1;GABBR2` cell
-creates a gene node that matches nothing, which is what capped mapping at ~85%.
-Each component gets its own row instead, so a row is identified by `mechanism_id`
-**plus** the gene, not `mechanism_id` alone. Components must be read one at a time —
-zipping separate symbol and HGNC lists misaligns them, because a component can have
-a symbol but no HGNC id. Keeping only the first component would cost ~6900 edges.
+Components are read one at a time rather than by zipping separate symbol and
+HGNC lists, which would misalign whenever a component has a symbol but no HGNC
+id.
+
+## Versioning
+
+The release is read from ChEMBL's `status.json` at run time and flows into the
+config, the graph version and the Zenodo metadata, so nothing needs editing when
+ChEMBL releases. The config is generated from `chembl_human_MoA.config.template`
+and is gitignored — do not hand-edit it.
+
+## Release
+
+Not yet deposited, and the deposit license is still undecided.

--- a/reactome/readme.md
+++ b/reactome/readme.md
@@ -1,46 +1,74 @@
-# Reactome pathway-gene linkset
+# Reactome linkset
 
-`reactome.py` builds one linkset input per species listed in `species.tsv`, plus
-`build/version.txt` and `build/manifest.tsv`. Per-species configs are generated
-into `reactome/config/` from `reactome.config.template` and are gitignored.
+Pathway–gene linkset for human, built from Reactome's `NCBI2Reactome.txt`.
+
+| | |
+| --- | --- |
+| Source | https://reactome.org (`NCBI2Reactome.txt`); gene symbols from NCBI Gene `gene_info` (public domain) |
+| License | CC0 1.0 — Reactome dedicates its data to the public domain |
+| DOI | not yet deposited — needs the one-time setup below |
+| Workflow | `.github/workflows/create-linkset-reactome.yml` |
+| Species | hsa |
+
+## How it works
+
+`reactome.py` resolves the release, downloads the pathway–gene table, and writes
+`input_<code>.txt` plus a generated `config/reactome_<code>.config` for each
+species. Genes enter as Entrez (`target_syscode_in=L`), are labelled with their
+NCBI gene symbol, and BridgeDb expands them to Ensembl, Entrez and UniProt, plus
+HGNC for human.
 
 ```bash
-python3 reactome/reactome.py --species hsa
-python3 reactome/reactome.py --version 97     # a specific release
+python3 reactome/reactome.py                    # all enabled species, current release
+python3 reactome/reactome.py --species hsa      # just this one
+python3 reactome/reactome.py --version 97       # a specific release
 ```
 
-Human only for now. Release 097 gives 2310 pathways, 11337 genes and 48811
-edges, with 99.8% of gene nodes mapped.
+Release 097 human: 2310 pathways, 11337 genes, 48811 edges, 99.8% mapped.
 
-## Gotchas
+## Input
 
-**The input is `NCBI2Reactome.txt`, not `ReactomePathways.gmt`.** The GMT looks
-like the WikiPathways analogue and is not: it is human-only, the bytes served at
-the `.gmt` URL are a ZIP archive, and the plain `.gmt` path 403s in the versioned
-archive, so it cannot support a pinned build. `NCBI2Reactome.txt` carries Entrez
-ids for every species and lands on the existing syscode `L`.
+`NCBI2Reactome.txt` rather than `ReactomePathways.gmt`. The GMT covers human
+only, is served as a ZIP archive under a `.gmt` name, and is not available in the
+versioned archive, so it cannot support a pinned build. The table carries Entrez
+ids for every species and is a plain TSV in both current and archived releases.
 
-**A (gene, pathway) pair can appear twice**, once `TAS` and once `IEA` — 4066 of
-them in human, an 8% edge inflation if written straight out. The pair is emitted
-once with the codes aggregated (`TAS`, `IEA`, `TAS+IEA`), so the evidence column
-is not a copy of the source column.
+Reactome lists a gene twice for a pathway when it is supported both by curation
+and by orthology projection, so pairs are de-duplicated and their `TAS`/`IEA`
+codes aggregated into one `evidence` column.
 
-**Genes NCBI has not named are rejected, not kept.** WikiPathways falls back to
-the Entrez id as a label; here the id is dropped, because the ones `gene_info`
-lacks are pathogen-side genes Reactome files under the host species in its
-infectious-disease pathways (*Escherichia ruysiae* `skp`, `secY`, `secE`) plus 22
-GenBank/RefSeq accessions that are not genes. None map in BridgeDb. The cost is
-real and counted: on release 097 this drops 3.4% of human genes and empties 30
-pathways, so `max_reject_frac` in `species.tsv` gates it.
+Genes NCBI has not named are dropped rather than kept under a bare identifier.
+These are pathogen-side genes that Reactome files under the host species in its
+infectious-disease pathways, and none of them map in BridgeDb. The share dropped
+is gated by `max_reject_frac` in `species.tsv` (human is 3.4%).
 
-**Versions are zero-padded to three digits.** The Zenodo gate compares version
-strings with the shell's `\<`, under which `100` sorts before `97`.
+## Species
 
-**"Lowest level" means lowest-level diagram, not leaf.** 325 of the 2343 human
-pathways still have children, so about 9% of pairs attribute a gene to both a
-pathway and an ancestor of it. The all-levels file is 3x larger and gives
-*Signal Transduction* 2622 genes, which is useless as a neighbour set.
+Human only. The other eleven buildable species are listed and commented out in
+`species.tsv`, because Reactome projects most non-human content from human by
+orthology — all 1467 mouse pathways share their name and numeric stem with a
+human pathway. Fly, chicken and yeast carry some natively curated pathways, so
+they are worth judging separately rather than as one group.
 
-**Non-human species are mostly orthology projections** and are all `off` in
-`species.tsv` pending a decision — see the comments there, which record which
-species are genuinely curated.
+Three further species have no BridgeDb bundle, and *M. tuberculosis* has no NCBI
+per-species `gene_info`, the same blocker recorded for horse, tomato and poplar
+in `wikipathways/species.tsv`.
+
+## Versioning
+
+The release is read from Reactome's ContentService at run time and zero-padded to
+three digits (`097`), so nothing needs editing when Reactome releases. The
+padding keeps the Zenodo version gate's string comparison correct past release
+100. Reactome releases quarterly.
+
+## Release
+
+Not yet deposited. Dispatch the workflow once with `bootstrap_zenodo` to create
+the first draft: it builds, QCs, uploads and sets the metadata, then stops
+without publishing, because minting a DOI cannot be undone. Review it at
+https://zenodo.org/me/uploads while logged in as the account that owns
+`ZENODO_ACCESS_TOKEN`, publish by hand, then set `ZENODO_DEPOSITION_ID` and
+`ZENODO_CONCEPT_ID` in the workflow and add a quarterly schedule.
+
+Metadata lives in `zenodo-metadata.sh` so the bootstrap and later versions cannot
+drift apart.


### PR DESCRIPTION
`CHEMBL/chembl_human_MoA.config` hardcoded `version=Chembl_35.0`, but the script
always fetches whatever ChEMBL is serving. The API reports ChEMBL_37 (released
2026-05-01), so the linkset has been labelling release 37 data as release 35.

That string ends up in the graph version, in the `datasource` attribute of every
edge, and in the Zenodo version field, which can't be changed after publishing.
So it was blocking #42.

`CHEMBL_MoA.py` now reads `chembl_db_version` from `status.json`, writes
`build/version.txt`, and generates the config from a template, which is
gitignored like the wikipathways/ and reactome/ ones. The workflow reads the
version from `build/version.txt` instead of sed-ing it out of the config.
Nothing needs editing when ChEMBL releases.

Checked locally: `resolve_version()` returns ChEMBL_37, and the generated config
reads `version=ChEMBL_37`.

Closes #55. This also rewrites the Reactome and ChEMBL readmes in the style
tflink/ and wikipathways/ use, which should let #44 close.