### PR TITLE
Shortlist candidate linkset resources by size, license and upstream activity

### DIFF
--- a/LinksetStatusList.md
+++ b/LinksetStatusList.md
@@ -36,12 +36,65 @@ yet and the deposit license is still undecided.
 
 Databases we would like to automate. No workflow yet.
 
-| Database | Interactions | Source |
-| --- | --- | --- |
-| DISEASES | disease–gene associations | https://diseases.jensenlab.org/Downloads |
-| CTD | chemical–target, chemical–disease, chemical–pathway | https://ctdbase.org/downloads |
-| TRRUST | transcription factor–target | https://www.grnpedia.org/trrust/ |
-| CollecTRI | transcription factor–target | https://github.com/saezlab/collecTRI |
+Size is the binding constraint. WikiPathways human is 40k edges (32 MB) and
+works; the GO linkset was removed at 226k edges (183 MB). What decides it is
+edges per gene, not rows in the source.
+
+### Ready to build
+
+Openly licensed, still curated upstream, and bounded as downloaded. Counts are
+human, measured from the current release.
+
+| Database | Interactions | Size | License | Source |
+| --- | --- | --- | --- | --- |
+| SIGNOR | signed, directed causal signalling | 19.6k edges, 6.4k proteins, median degree 2 | CC BY 4.0 | https://signor.uniroma2.it/getData.php?organism=9606 |
+| Guide to PHARMACOLOGY | ligand–target | 17.5k pairs, 1.9k targets, 9.6k ligands | ODbL, contents CC BY-SA 4.0 | https://www.guidetopharmacology.org/DATA/interactions.csv |
+| Complex Portal | complex–component | 9.6k edges, 2.5k complexes | CC0 | https://ftp.ebi.ac.uk/pub/databases/intact/complex/current/complextab/ |
+| Ensembl Compara | gene–ortholog | 15.8k one-to-one pairs for human–rat | open | https://ftp.ensembl.org/pub/current/tsv/ensembl-compara/homologies/ |
+
+SIGNOR is one TSV request per organism and carries an effect (up- or
+down-regulates) on every edge; it is the only directed, signed resource here.
+Guide to PHARMACOLOGY is share-alike, so its deposit cannot be CC BY. The
+Complex Portal ComplexTAB files hold the curated complexes only — the hu.MAP
+predicted set is not in them, and there is one file per taxon. Ensembl
+homologies are filtered to `homology_type == ortholog_one2one`, which holds the
+linkset to one edge per gene per species pair and lets a network built for one
+species extend into another; the filename carries the release number, so the
+release is resolved at run time as WikiPathways already does.
+
+### Needs a decision first
+
+Worth having, but not usable as downloaded.
+
+| Database | Interactions | Decision | Source |
+| --- | --- | --- | --- |
+| HPO | gene–disease, gene–phenotype | `genes_to_disease` (~3.5 per gene), not `genes_to_phenotype` (~78 per gene) | https://github.com/obophenotype/human-phenotype-ontology/releases |
+| DISEASES | disease–gene | confidence cutoff for the text-mining channel; the knowledge and experiments channels are bounded as they are | https://diseases.jensenlab.org/Downloads |
+| CTD | chemical–gene, chemical–disease, chemical–pathway | ~3.8M curated chemical–gene interactions, so needs filtering by organism and interaction action. The terms of use do not say whether a derived file may be redistributed | https://ctdbase.org/downloads |
+| Open Targets | target–disease | CC0 and quarterly, but 17M associations — needs a score threshold that can be defended | https://platform.opentargets.org/downloads |
+| miRTarBase | microRNA–target gene | the strong-evidence subset (reporter assay, Western blot), not the full 3.8M | https://awi.cuhk.edu.cn/miRTarBase/ |
+| TarBase | microRNA–target gene | CC BY 4.0, better licensed than miRTarBase; filter to the low-throughput methods | https://dianalab.e-ce.uth.gr/tarbasev9 |
+| AOP-Wiki | key event–gene | no gene table upstream; would be derived through the KE–WikiPathways mappings, and coverage is partial | https://aopwiki.org |
+
+### Not worth a workflow
+
+Upstream no longer releases, so a scheduled build gains nothing over a one-off.
+
+| Database | Last release |
+| --- | --- |
+| TRRUST | 2018 |
+| CollecTRI | 2023 |
+| CORUM | 2024 |
+| HuRI | 2020 |
+| SIDER | 2015 |
+| NCBI HomoloGene | retired 2024 |
+
+### Too large
+
+These would repeat the GO problem: STRING (usable only above a 0.9 cutoff),
+IntAct and BioGRID in full, RegNetwork (11M interactions), hTFtarget (3.2M),
+InterPro/Pfam domains, Rhea, CellMarker (~32 cell types per gene), and predicted
+microRNA targets such as miRDB and TargetScan (500–600 targets per microRNA).
 
 ## License limitation
 
@@ -52,7 +105,8 @@ their own copy of the source data, without shipping the data files.
 | Database | Interactions | Source |
 | --- | --- | --- |
 | DrugBank | drug–target | https://go.drugbank.com/ |
-| DisGeNET | gene–disease associations | https://www.disgenet.org/ |
+| DisGeNET | gene–disease associations | https://www.disgenet.com/ |
+| MalaCards | gene–disease associations | https://www.malacards.org/ |
 
 ## Supporting workflows
 


### PR DESCRIPTION
The candidate list named four databases without saying what a linkset built from each would cost. Size is what decides it. WikiPathways human is 40k edges at 32 MB and works fine; the GO linkset was removed at 226k edges and 183 MB. The number that matters is edges per gene, not rows in the source.

Candidates are now grouped by what blocks each one. SIGNOR, Guide to PHARMACOLOGY, Complex Portal and Ensembl Compara orthologs are openly licensed and small enough to use as downloaded, and all four are still curated upstream. I measured their sizes from the current releases rather than taking them from the papers: SIGNOR human is 19.6k edges over 6.4k proteins at a median degree of 2, Guide to PHARMACOLOGY 17.5k ligand-target pairs, Complex Portal 9.6k edges over 2.5k curated complexes, and Ensembl gives 15.8k one-to-one orthologs for human-rat. HPO, DISEASES, CTD, Open Targets, miRTarBase, TarBase and AOP-Wiki each need one decision settled before a workflow is worth writing, and each row says which.

TRRUST and CollecTRI move out of the candidate list. Neither has released since 2018 and 2023, so a scheduled build gains nothing over a one-off, and they now sit with CORUM, HuRI, SIDER and the retired HomoloGene. STRING, IntAct, BioGRID, RegNetwork, hTFtarget, Pfam, Rhea, CellMarker and the predicted microRNA target sets are listed as too large, with the figure that rules each one out.

MalaCards is added to the license-limitation table, and DisGeNET's URL now points at disgenet.com.

One caveat: the SIGNOR, Guide to PHARMACOLOGY and Complex Portal counts are measured. The CTD, HPO, miRTarBase and Open Targets figures come from release notes and papers, and I have not checked them independently.