### PR TITLE
Record why ontologies do not fit a linkset, and drop the em-dashes

### DIFF
--- a/LinksetStatusList.md
+++ b/LinksetStatusList.md
@@ -36,10 +36,8 @@ yet and the deposit license is still undecided.
 
 Databases we would like to automate. No workflow yet.
 
-Two things rule a resource out. The first is size, measured as edges per gene
-rather than rows in the source: WikiPathways human is 40k edges (32 MB) and
-works. The second is shape, which is what an ontology has and a linkset does
-not. See below.
+Two things rule a resource out: too many edges per gene (WikiPathways human is
+40k edges and works), and ontology shape, below.
 
 ### Ready to build
 
@@ -52,11 +50,9 @@ human, measured from the current release.
 | Guide to PHARMACOLOGY | ligand–target | 17.5k pairs, 1.9k targets, 9.6k ligands | ODbL, contents CC BY-SA 4.0 | https://www.guidetopharmacology.org/DATA/interactions.csv |
 | Complex Portal | complex–component | 9.6k edges, 2.5k complexes | CC0 | https://ftp.ebi.ac.uk/pub/databases/intact/complex/current/complextab/ |
 
-SIGNOR is one TSV request per organism and carries an effect (up- or
-down-regulates) on every edge; it is the only directed, signed resource here.
-Guide to PHARMACOLOGY is share-alike, so its deposit cannot be CC BY. The
-Complex Portal ComplexTAB files hold the curated complexes only; the hu.MAP
-predicted set is not in them, and there is one file per taxon.
+SIGNOR is one TSV request per organism and the only signed, directed resource
+here. Guide to PHARMACOLOGY is share-alike, so its deposit cannot be CC BY.
+Complex Portal's ComplexTAB files are curated only, one per taxon.
 
 ### Needs a decision first
 
@@ -75,9 +71,8 @@ Worth having, but not usable as downloaded.
 
 ### Not worth a workflow
 
-These release rarely or not at all, so a scheduled build gains nothing over a
-one-off. Several are still worth having as a linkset; they just do not need
-automating.
+These release rarely or not at all, so a schedule gains nothing over a one-off.
+Still worth building by hand if wanted.
 
 | Database | Interactions | Last release |
 | --- | --- | --- |
@@ -90,8 +85,7 @@ automating.
 
 ### Too large
 
-These attach too many edges per gene to be useful for extension. The figure is
-what rules each one out.
+Too many edges per gene to be useful. The figure is what rules each one out.
 
 | Database | Interactions | Size |
 | --- | --- | --- |
@@ -105,24 +99,12 @@ what rules each one out.
 
 ### Ontologies
 
-Ontology-backed resources do not flatten into a linkset. Annotations obey the
-true-path rule, so a gene annotated to one term is annotated to every ancestor
-of that term, and each gene arrives carrying its whole branch up to the root.
-Dropping the ancestors fixes the degree but throws away the term-to-term
-relations, and that is where an ontology keeps its meaning. A linkset has no way
-to express those relations, so neither choice leaves anything useful. This, not
-the file size, is why the GO linkset was removed. A slim does not solve it
-either: its terms are sampled, so the relations are still lost, and genes reach
-the surviving terms by propagation, which turns the generic ones into hubs.
-
-The same structure is worth checking in anything hierarchical. Reactome pathways
-have one, which is why the pipeline reads `NCBI2Reactome.txt` and not
-`NCBI2Reactome_All_Levels.txt`: the same 11,788 human genes give 54k edges at a
-median of 2 pathways per gene from the lowest level, against 160k edges at a
-median of 7 and a maximum of 525 once every parent is counted. HPO behaves the
-same way, which is what the ~78 terms per gene in `genes_to_phenotype` are,
-while `genes_to_disease` escapes it because diseases are flat identifiers and
-not a tree. Bgee's anatomy terms come from UBERON and carry the same hierarchy.
+Annotations propagate up the tree, so a gene arrives carrying its whole branch.
+Dropping the ancestors instead loses the term-to-term relations, which a linkset
+cannot express anyway. That, not file size, is why the GO linkset went, and a
+slim does not fix it. Reactome shows the scale: the same 11,788 human genes give
+54k edges from `NCBI2Reactome.txt` and 160k from `_All_Levels`, which is why the
+pipeline reads the first. HPO and Bgee are the same shape.
 
 ### Assessed, not queued
 

--- a/LinksetStatusList.md
+++ b/LinksetStatusList.md
@@ -8,9 +8,9 @@ linkset exists at all. Several databases below already have linksets on the
 were built by hand before this repository existed; they still appear as
 candidates because the build is not yet automated.
 
-Deposit details — persistent DOIs, licenses and per-resource build notes — live
-in the resource table in [`README.md`](README.md#linkset-resources) rather than
-being repeated here.
+Deposit details, meaning persistent DOIs, licenses and per-resource build
+notes, live in the resource table in [`README.md`](README.md#linkset-resources)
+rather than being repeated here.
 
 ## In production
 
@@ -36,9 +36,10 @@ yet and the deposit license is still undecided.
 
 Databases we would like to automate. No workflow yet.
 
-Size is the binding constraint. WikiPathways human is 40k edges (32 MB) and
-works; the GO linkset was removed at 226k edges (183 MB). What decides it is
-edges per gene, not rows in the source.
+Two things rule a resource out. The first is size, measured as edges per gene
+rather than rows in the source: WikiPathways human is 40k edges (32 MB) and
+works. The second is shape, which is what an ontology has and a linkset does
+not. See below.
 
 ### Ready to build
 
@@ -54,7 +55,7 @@ human, measured from the current release.
 SIGNOR is one TSV request per organism and carries an effect (up- or
 down-regulates) on every edge; it is the only directed, signed resource here.
 Guide to PHARMACOLOGY is share-alike, so its deposit cannot be CC BY. The
-Complex Portal ComplexTAB files hold the curated complexes only — the hu.MAP
+Complex Portal ComplexTAB files hold the curated complexes only; the hu.MAP
 predicted set is not in them, and there is one file per taxon.
 
 ### Needs a decision first
@@ -63,10 +64,10 @@ Worth having, but not usable as downloaded.
 
 | Database | Interactions | Decision | Source |
 | --- | --- | --- | --- |
-| HPO | gene–disease, gene–phenotype | `genes_to_disease` (~3.5 per gene), not `genes_to_phenotype` (~78 per gene) | https://github.com/obophenotype/human-phenotype-ontology/releases |
+| HPO | gene–disease, gene–phenotype | `genes_to_disease` (~3.5 per gene), not `genes_to_phenotype` (~78 per gene, mostly propagated ancestors) | https://github.com/obophenotype/human-phenotype-ontology/releases |
 | DISEASES | disease–gene | confidence cutoff for the text-mining channel; the knowledge and experiments channels are bounded as they are | https://diseases.jensenlab.org/Downloads |
 | CTD | chemical–gene, chemical–disease, chemical–pathway | ~3.8M curated chemical–gene interactions, so needs filtering by organism and interaction action. The terms of use do not say whether a derived file may be redistributed | https://ctdbase.org/downloads |
-| Open Targets | target–disease | CC0 and quarterly, but 17M associations — needs a score threshold that can be defended | https://platform.opentargets.org/downloads |
+| Open Targets | target–disease | CC0 and quarterly, but 17M associations, so it needs a score threshold that can be defended | https://platform.opentargets.org/downloads |
 | miRTarBase | microRNA–target gene | the strong-evidence subset (reporter assay, Western blot), not the full 3.8M | https://awi.cuhk.edu.cn/miRTarBase/ |
 | TarBase | microRNA–target gene | CC BY 4.0, better licensed than miRTarBase; filter to the low-throughput methods | https://dianalab.e-ce.uth.gr/tarbasev9 |
 | TransmiR | transcription factor–microRNA | the literature-curated tier (~5k pairs), not the ChIP-seq or motif-predicted tiers | https://www.cuilab.cn/transmir |
@@ -89,12 +90,11 @@ automating.
 
 ### Too large
 
-These would repeat the GO problem. The figure is what rules each one out.
+These attach too many edges per gene to be useful for extension. The figure is
+what rules each one out.
 
 | Database | Interactions | Size |
 | --- | --- | --- |
-| GO, full | gene–term | removed at 226k edges, 183 MB |
-| STRING | functional association | usable only above a 0.9 cutoff |
 | IntAct, BioGRID | protein–protein | ~848k interactions in full; IntAct needs MI > 0.6 |
 | RegNetwork | transcription factor–target | 11M interactions |
 | hTFtarget | transcription factor–target | 3.2M regulations |
@@ -103,12 +103,34 @@ These would repeat the GO problem. The figure is what rules each one out.
 | InterPro, Pfam | protein family–gene | several domains per gene |
 | Rhea | enzyme–reaction | several reactions per enzyme |
 
+### Ontologies
+
+Ontology-backed resources do not flatten into a linkset. Annotations obey the
+true-path rule, so a gene annotated to one term is annotated to every ancestor
+of that term, and each gene arrives carrying its whole branch up to the root.
+Dropping the ancestors fixes the degree but throws away the term-to-term
+relations, and that is where an ontology keeps its meaning. A linkset has no way
+to express those relations, so neither choice leaves anything useful. This, not
+the file size, is why the GO linkset was removed. A slim does not solve it
+either: its terms are sampled, so the relations are still lost, and genes reach
+the surviving terms by propagation, which turns the generic ones into hubs.
+
+The same structure is worth checking in anything hierarchical. Reactome pathways
+have one, which is why the pipeline reads `NCBI2Reactome.txt` and not
+`NCBI2Reactome_All_Levels.txt`: the same 11,788 human genes give 54k edges at a
+median of 2 pathways per gene from the lowest level, against 160k edges at a
+median of 7 and a maximum of 525 once every parent is counted. HPO behaves the
+same way, which is what the ~78 terms per gene in `genes_to_phenotype` are,
+while `genes_to_disease` escapes it because diseases are flat identifiers and
+not a tree. Bgee's anatomy terms come from UBERON and carry the same hierarchy.
+
 ### Assessed, not queued
 
 Looked at and not taken further, recorded so the assessment is not repeated.
 
 | Database | Interactions | Why not |
 | --- | --- | --- |
+| STRING | functional association | Cytoscape's stringApp already extends a network from STRING, so a linkset would duplicate tooling that exists |
 | OmniPath | aggregated signalling | no single bulk file, and the license varies by contributing resource |
 | DGIdb | drug–gene | aggregates 44 sources under differing licenses, so provenance would have to be tracked per edge |
 | DrugCentral | drug–target | CC BY-SA and usable, but overlaps ChEMBL and Guide to PHARMACOLOGY |
@@ -123,9 +145,8 @@ Looked at and not taken further, recorded so the assessment is not repeated.
 | CIViC | variant–cancer evidence | CC0 and bounded, but variant-level and cancer-only |
 | MGI, RGD | gene–phenotype | mouse and rat phenotype; revisit if a non-human disease linkset is wanted |
 | Human Protein Atlas | gene–tissue, gene–cell type | CC BY 4.0, but needs the enriched classification rather than all expression calls |
-| Bgee | gene–anatomy | needs a tissue subset chosen first |
+| Bgee | gene–anatomy | UBERON anatomy is hierarchical, so it needs a tissue subset chosen first |
 | MSigDB Hallmark | gene–gene set | 50 sets and bounded, but MSigDB collections differ in license and not all are open |
-| GO slim | gene–term | the bounded alternative to the removed GO linkset; needs a slim chosen and its coverage checked |
 | PathBank, SMPDB | gene–pathway | CC BY 4.0, but overlaps WikiPathways and Reactome, and currency is unclear |
 | InnateDB | protein–protein | curated but narrow, innate immunity only |
 | PanglaoDB | cell type–marker gene | CC0, but currency unclear |
@@ -151,7 +172,7 @@ their own copy of the source data, without shipping the data files.
 
 Not linksets themselves, but part of the build:
 
-- [`update-bridgedb.yml`](.github/workflows/update-bridgedb.yml) — refreshes the
+- [`update-bridgedb.yml`](.github/workflows/update-bridgedb.yml) refreshes the
   cached BridgeDb identifier-mapping bundle that every linkset build restores.
-- [`qc-xgmml.yml`](.github/workflows/qc-xgmml.yml) — validates a built XGMML
+- [`qc-xgmml.yml`](.github/workflows/qc-xgmml.yml) validates a built XGMML
   linkset; callable from another workflow or triggered manually.


### PR DESCRIPTION
The file recorded the GO linkset as having been removed for size. That was the symptom rather than the cause. Annotations obey the true-path rule, so a gene annotated to one term is annotated to every ancestor of it and arrives carrying its whole branch up to the root. Dropping the ancestors fixes the degree but throws away the term-to-term relations, which a linkset has no way to express in the first place. Neither choice leaves anything worth shipping, and a slim does not help, since it samples terms and loses the same relations while genes still reach the survivors by propagation.

There is now an Ontologies section saying this, with a measurement that makes it concrete. Reactome has a pathway hierarchy, and the pipeline already reads NCBI2Reactome.txt rather than NCBI2Reactome_All_Levels.txt. The same 11,788 human genes give 54k edges at a median of 2 pathways per gene from the lowest level, against 160k edges at a median of 7 and a maximum of 525 once every parent is counted. That was worth writing down because the existing choice looks arbitrary otherwise. HPO and Bgee carry the same structure, so their rows now say where the degree comes from: the ~78 terms per gene in genes_to_phenotype are mostly propagated ancestors, and genes_to_disease escapes it because diseases are flat identifiers.

STRING moves out of the too-large table. It is ruled out because Cytoscape's stringApp already extends a network from STRING, which is a duplication argument and not a size one, so it sits with the other varied reasons. The GO slim row goes too, since the new section explains why a slim is not the way out.

Em-dashes are removed throughout, including from a few lines that predate this work.